### PR TITLE
Uupdate ORCID auth flow

### DIFF
--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -547,7 +547,10 @@
     "error-verifying": "Error verifying with ORCID.org",
     "verified-with": "Successfully verified with ORCID.org",
     "verify-header-text": "Connect your ORCID iD (or register for an iD)",
-    "verifying": "Verifying with ORCID.org"
+    "verifying": "Verifying with ORCID.org",
+    "invalid-key": "Invalid key - likely due to timeout - please try again.",
+    "invalid-user": "User not found - internal error - please contact us.",
+    "failed": "A probelm occured in authorizing your account with ORCID.org"
   },
   "organization-select": {
     "add-a-new-organization": "Add a new organization",

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -547,7 +547,10 @@
     "error-verifying": "Erreur lors de la vérification avec ORCID.org",
     "verified-with": "Vérifié avec succès avec ORCID.org",
     "verify-header-text": "Connectez votre ORCID iD (ou inscrivez-vous pour un iD)",
-    "verifying": "Vérification avec ORCID.org"
+    "verifying": "Vérification avec ORCID.org",
+    "invalid-key": "Clé non valide - probablement en raison d'un délai d'attente - veuillez réessayer.",
+    "invalid-user": "Utilisateur introuvable – erreur interne – veuillez nous contacter.",
+    "failed": "Un problème est survenu lors de l'autorisation de votre compte avec ORCID.org"
   },
   "organization-select": {
     "add-a-new-organization": "Ajouter une nouvelle organisation",

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,7 +41,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/status', CheckStatusPageController::class);
-Route::get('/orcid/redirect', [FullFlowController::class, 'redirectToFrontend']);
+Route::get('/orcid/callback', [FullFlowController::class, 'callback']);
 
 // Need to ben authenticated to access these routes
 Route::middleware(['auth:sanctum'])->group(function () {
@@ -56,7 +56,6 @@ Route::middleware(['auth:sanctum'])->group(function () {
     // Route::post('/user/orcid/verify', ImplicitFlowController::class);
     // Route::get('/user/orcid/verify', [ImplicitFlowController::class, 'redirect']);
     // Routes for 3-legged OAuth flow
-    Route::post('/user/orcid/verify', FullFlowController::class);
     Route::get('/user/orcid/verify', [FullFlowController::class, 'redirect']);
 
     Route::controller(AuthorController::class)->group(function () {

--- a/tests/Feature/OrcidIntegrationTest.php
+++ b/tests/Feature/OrcidIntegrationTest.php
@@ -21,11 +21,6 @@ test('check OpenID redirect works', function () {
     $response = $this->actingAs($user)->get('api/user/orcid/verify?locale=fr');
 
     expect($response->status())->toBe(302);
-    expect($response->headers->get('Location'))->toBe("https://orcid.org/oauth/authorize?client_id=$client_id&response_type=code&scope=$scopes&redirect_uri=$encoded&lang=fr");
-});
+    expect($response->headers->get('Location'))->toStartWith("https://orcid.org/oauth/authorize?client_id=$client_id&response_type=code&scope=$scopes&redirect_uri=$encoded")->toEndWith('&lang=fr');
 
-test('check front end redirect rule', function () {
-    $response = $this->get('/api/orcid/redirect?code=1234');
-    expect($response->status())->toBe(302);
-    expect($response->headers->get('Location'))->toBe(config('app.frontend_url').'#/auth/orcid-callback?code=1234');
 });


### PR DESCRIPTION
Update the ORCID flow to remove use of `#` in the redirect URI. System now uses cache to save a one-time use key to identify the user on the callback.