### PR TITLE
feat: add OGL question to DFO pub MRF

### DIFF
--- a/app/Http/Controllers/ManuscriptRecordController.php
+++ b/app/Http/Controllers/ManuscriptRecordController.php
@@ -19,6 +19,7 @@ use App\Rules\UserNotAManuscriptAuthor;
 use Gate;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 
@@ -40,7 +41,7 @@ class ManuscriptRecordController extends Controller
 
         $manuscriptRecord = new ManuscriptRecord($validated);
         $manuscriptRecord->status = ManuscriptRecordStatus::DRAFT;
-        $manuscriptRecord->user_id = auth()->id();
+        $manuscriptRecord->user_id = Auth::id();
         $manuscriptRecord->save();
         $manuscriptRecord->refresh();
 
@@ -72,8 +73,10 @@ class ManuscriptRecordController extends Controller
             'abstract' => 'nullable|string',
             'pls' => 'nullable|string',
             'relevant_to' => 'nullable|string',
-            'additional_information' => 'nullable|string',
+            'public_interest_information' => 'nullable|string',
             'potential_public_interest' => 'boolean',
+            'do_not_apply_ogl' => 'boolean',
+            'no_ogl_explanation' => 'nullable|string',
         ]);
 
         $manuscriptRecord->update($validated);

--- a/app/Http/Resources/ManuscriptRecordResource.php
+++ b/app/Http/Resources/ManuscriptRecordResource.php
@@ -31,8 +31,10 @@ class ManuscriptRecordResource extends JsonResource
                 'abstract' => $this->abstract ?? '',
                 'pls' => $this->pls ?? '',
                 'relevant_to' => $this->relevant_to ?? '',
-                'additional_information' => $this->additional_information ?? '',
                 'potential_public_interest' => $this->potential_public_interest,
+                'public_interest_information' => $this->public_interest_information ?? '',
+                'do_not_apply_ogl' => $this->do_not_apply_ogl,
+                'no_ogl_explanation' => $this->no_ogl_explanation ?? '',
 
                 // dates and times
                 'created_at' => $this->created_at,

--- a/app/Models/ManuscriptRecord.php
+++ b/app/Models/ManuscriptRecord.php
@@ -51,6 +51,7 @@ class ManuscriptRecord extends Model implements Fundable, HasMedia
         'type' => ManuscriptRecordType::class,
         'status' => ManuscriptRecordStatus::class,
         'potential_public_interest' => 'boolean',
+        'do_not_apply_ogl' => 'boolean',
     ];
 
     // default values for optional fields
@@ -58,7 +59,8 @@ class ManuscriptRecord extends Model implements Fundable, HasMedia
         'abstract' => '',
         'pls' => '',
         'relevant_to' => '',
-        'additional_information' => '',
+        'public_interest_information' => '',
+        'no_ogl_explanation' => '',
     ];
 
     // logging options
@@ -233,6 +235,7 @@ class ManuscriptRecord extends Model implements Fundable, HasMedia
             'region_id' => 'required|exists:regions,id',
             'functional_area_id' => 'required|exists:functional_areas,id',
             'relevant_to' => 'required',
+            'no_ogl_explanation' => 'required_if:do_not_apply_ogl,true',
         ]);
 
         $validator->after(function ($validator) {

--- a/database/factories/ManuscriptRecordFactory.php
+++ b/database/factories/ManuscriptRecordFactory.php
@@ -44,7 +44,7 @@ class ManuscriptRecordFactory extends Factory
             'pls' => $this->faker->paragraph(),
             'relevant_to' => $this->faker->paragraph(),
             'potential_public_interest' => $this->faker->boolean(),
-            'additional_information' => $this->faker->paragraph(),
+            'public_interest_information' => $this->faker->paragraph(),
             'functional_area_id' => FunctionalArea::factory()->create()->id,
         ])->afterCreating(function ($manuscript) {
             $manuscript->manuscriptAuthors()->save(ManuscriptAuthor::factory()->make(['is_corresponding_author' => true])); // create a corresponding author

--- a/database/migrations/2024_11_14_184759_add_ogl_question_to_manuscript_records_table.php
+++ b/database/migrations/2024_11_14_184759_add_ogl_question_to_manuscript_records_table.php
@@ -17,5 +17,4 @@ return new class extends Migration
             $table->renameColumn('additional_information', 'public_interest_information');
         });
     }
-
 };

--- a/database/migrations/2024_11_14_184759_add_ogl_question_to_manuscript_records_table.php
+++ b/database/migrations/2024_11_14_184759_add_ogl_question_to_manuscript_records_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('manuscript_records', function (Blueprint $table) {
+            $table->boolean('do_not_apply_ogl')->default(false);
+            $table->text('no_ogl_explanation')->nullable();
+            $table->renameColumn('additional_information', 'public_interest_information');
+        });
+    }
+
+};

--- a/resources/src/components/QuestionEditor.vue
+++ b/resources/src/components/QuestionEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { QEditor } from 'quasar'
 import DOMPurify from 'dompurify'
+import { QEditor } from 'quasar'
 import RequiredSpan from './RequiredSpan.vue'
 
 const props = withDefaults(
@@ -10,11 +10,13 @@ const props = withDefaults(
     disable?: boolean
     readonly?: boolean
     required?: boolean
+    hideEditor?: boolean
   }>(),
   {
     disable: false,
     readonly: false,
     required: false,
+    hideEditor: false,
   },
 )
 
@@ -66,6 +68,7 @@ function onPaste(e: ClipboardEvent) {
       </div>
     </div>
     <QEditor
+      v-if="!hideEditor"
       ref="editor"
       v-model="value"
       :disable="disable"

--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -519,7 +519,12 @@
     "upload-manuscript": "Upload manuscript",
     "upload-text": "Upload the most recent copy of your manuscript as a PDF. This file can be updated as required by the applicant, even after submitting the manuscript.",
     "working-title-text": "Enter to the manuscript's working title. You will be able to modify the title when you update this manuscript status to published.",
-    "functional-area-text": "In order to improve reporting on research outputs, please select the relevant functional area for this manuscript."
+    "functional-area-text": "In order to improve reporting on research outputs, please select the relevant functional area for this manuscript.",
+    "no-ogl-explanation": "Report Licensing",
+    "no-ogl-explanation-text-field-text": "DFO is committed to the \"Open by Design and by Default\" principle of Open Science, which means that all DFO publications will be published under the latest version of the \"{url}\" Are there any specific reasons or concerns that would prevent your report from being licensed under this Open Government Licence?",
+    "ogl-link": "Open Government Licence - Canada",
+    "do_not_apply_ogl": "We have reasons not to apply an open license for this report.",
+    "ogl-provide-explanation": "Since you answered \"yes,\" please provide an explanation of why an open license cannot be applied to your report."
   },
   "my-manuscript-records": {
     "actions-still-required": "Actions still required",

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -519,7 +519,12 @@
     "upload-manuscript": "Télécharger le manuscrit",
     "upload-text": "Téléchargez la copie la plus récente de votre manuscrit au format PDF. \nCe fichier peut être mis à jour selon les besoins du demandeur, même après la soumission du manuscrit.",
     "working-title-text": "Entrez le titre provisoir du manuscrit. \nVous pourrez modifier le titre lorsque vous mettrez à jour le statut de ce manuscrit à publié.",
-    "functional-area-text": "Afin d'améliorer les rapports sur les résultats de la recherche, veuillez sélectionner le domaine fonctionnel pertinent pour ce manuscrit."
+    "functional-area-text": "Afin d'améliorer les rapports sur les résultats de la recherche, veuillez sélectionner le domaine fonctionnel pertinent pour ce manuscrit.",
+    "no-ogl-explanation-text-field-text": "Le MPO s'engage à suivre le principe « ouvert par conception et par défaut » de la science ouverte. Par conséquent, toutes les publications du MPO seront publiées sous la dernière version de la « {url} ». Avez-vous des raisons de croire que votre rapport ne devrait pas être licencié sous cette licence du gouvernement ouvert?",
+    "ogl-link": "Licence du gouvernement ouvert – Canada",
+    "do_not_apply_ogl": "Nous avons des raisons de ne pas appliquer une licence ouverte pour ce rapport.",
+    "no-ogl-explanation": "Licence de rapport",
+    "ogl-provide-explanation": "Puisque vous avez répondu « oui », veuillez expliquer pourquoi une licence ouverte ne peut pas être appliquée à votre rapport."
   },
   "my-manuscript-records": {
     "actions-still-required": "Actions encore nécessaires",

--- a/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
+++ b/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
@@ -1,3 +1,5 @@
+import type { ManuscriptAuthorResource } from '@/models/ManuscriptAuthor/ManuscriptAuthor'
+import type { FunctionalArea } from '../FunctionalArea/FunctionalArea'
 import type { PublicationResource } from '../Publication/Publication'
 import type { Region } from '../Region/Region'
 import type {
@@ -7,10 +9,8 @@ import type {
   ResourceList,
 } from '../Resource'
 import type { UserResource } from '../User/User'
-import type { FunctionalArea } from '../FunctionalArea/FunctionalArea'
-import type { ManuscriptAuthorResource } from '@/models/ManuscriptAuthor/ManuscriptAuthor'
-import { SpatieQuery } from '@/api/SpatieQuery'
 import { http } from '@/api/http'
+import { SpatieQuery } from '@/api/SpatieQuery'
 
 export type ManuscriptRecordType = 'primary' | 'secondary'
 
@@ -46,8 +46,10 @@ export interface ManuscriptRecord extends BaseManuscriptRecord {
   abstract: string
   pls: string
   relevant_to: string
-  additional_information: string
   potential_public_interest: boolean
+  public_interest_information: string
+  do_not_apply_ogl: boolean
+  no_ogl_explanation: string
   readonly sent_for_review_at: string | null
   readonly reviewed_at: string | null
   submitted_to_journal_on: string | null
@@ -90,7 +92,7 @@ export class ManuscriptRecordService {
    */
   public static async find(id: number) {
     const response = await http.get<ManuscriptRecordResource>(
-            `${this.baseURL}/${id}`,
+      `${this.baseURL}/${id}`,
     )
     return response.data
   }
@@ -137,13 +139,13 @@ export class ManuscriptRecordService {
     const formData = new FormData()
     formData.append('pdf', file)
     const response = await http.post<FormData, MediaResource>(
-            `${this.baseURL}/${id}/files`,
-            formData,
-            {
-              headers: {
-                'Content-Type': 'multipart/form-data',
-              },
-            },
+      `${this.baseURL}/${id}/files`,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
     )
     return response.data
   }
@@ -151,7 +153,7 @@ export class ManuscriptRecordService {
   /** List all PDF files associated with this manuscript */
   public static async listPDFs(id: number) {
     const response = await http.get<MediaResourceList>(
-            `${this.baseURL}/${id}/files`,
+      `${this.baseURL}/${id}/files`,
     )
     return response.data
   }
@@ -162,7 +164,7 @@ export class ManuscriptRecordService {
    */
   public static async deletePDF(id: number, uuid: string) {
     const response = await http.delete(
-            `${this.baseURL}/${id}/files/${uuid}`,
+      `${this.baseURL}/${id}/files/${uuid}`,
     )
     return response.status === 204
   }
@@ -173,8 +175,8 @@ export class ManuscriptRecordService {
       reviewer_user_id: userId,
     }
     const response = await http.put<any, ManuscriptRecordResource>(
-            `${this.baseURL}/${id}/submit-for-review`,
-            data,
+      `${this.baseURL}/${id}/submit-for-review`,
+      data,
     )
     return response.data
   }
@@ -185,8 +187,8 @@ export class ManuscriptRecordService {
       submitted_to_journal_on: date,
     }
     const response = await http.put<any, ManuscriptRecordResource>(
-            `${this.baseURL}/${id}/submitted`,
-            data,
+      `${this.baseURL}/${id}/submitted`,
+      data,
     )
     return response.data
   }
@@ -204,8 +206,8 @@ export class ManuscriptRecordService {
       journal_id: journalId,
     }
     const response = await http.put<any, ManuscriptRecordResource>(
-            `${this.baseURL}/${id}/accepted`,
-            data,
+      `${this.baseURL}/${id}/accepted`,
+      data,
     )
     return response.data
   }
@@ -213,7 +215,7 @@ export class ManuscriptRecordService {
   // Withdraw the manuscript
   public static async withdraw(id: number) {
     const response = await http.put<any, ManuscriptRecordResource>(
-            `${this.baseURL}/${id}/withdraw`,
+      `${this.baseURL}/${id}/withdraw`,
     )
     return response.data
   }

--- a/tests/Feature/Models/ManuscriptRecordTest.php
+++ b/tests/Feature/Models/ManuscriptRecordTest.php
@@ -270,6 +270,23 @@ test('a user can mark their manuscript as submitted', function () {
     expect($manuscript->fresh()->status)->toBe(ManuscriptRecordStatus::SUBMITTED);
 });
 
+test('a user cannot submit their manuscript for review if they do not want an OGL but have provide no explanation', function () {
+    $manuscript = ManuscriptRecord::factory()->filled()->create([
+        'do_not_apply_ogl' => true,
+    ]);
+
+    $this->actingAs($manuscript->user)->putJson("/api/manuscript-records/{$manuscript->id}/submit-for-review", [
+        'reviewer_user_id' => User::factory()->create()->id,
+    ])->assertStatus(422);
+
+    $manuscript->no_ogl_explanation = 'I do not want to apply for OGL';
+    $manuscript->save();
+
+    $this->actingAs($manuscript->user)->putJson("/api/manuscript-records/{$manuscript->id}/submit-for-review", [
+        'reviewer_user_id' => User::factory()->create()->id,
+    ])->assertOk();
+});
+
 test('a user can mark their manuscript as accepted', function () {
     // create a manuscript that has been submitted
     $manuscript = ManuscriptRecord::factory()->filled()->create([


### PR DESCRIPTION
This pull request includes several changes to the `ManuscriptRecord` model and its related components, controllers, and resources. The changes introduce new fields and validation rules, update existing fields, and add new migration files to support these updates. Additionally, there are updates to the front-end components to reflect these changes.

### Backend Changes:
* Added new fields `do_not_apply_ogl` and `no_ogl_explanation` to the `ManuscriptRecord` model and updated the corresponding validation rules and attributes. [[1]](diffhunk://#diff-20cdfc12bdbe745679d4682a792e9f164ae342fc3bdbd98616fc61946a803b99R54-R63) [[2]](diffhunk://#diff-20cdfc12bdbe745679d4682a792e9f164ae342fc3bdbd98616fc61946a803b99R238)
* Renamed the `additional_information` field to `public_interest_information` in the `ManuscriptRecord` model and updated the relevant methods and resources. (Fb21f90bL31R31, [app/Http/Resources/ManuscriptRecordResource.phpL34-R37](diffhunk://#diff-75fba6d2818348c37cf78138674214e63821e2e19f93918a1ac2ad3eaf8b8f9dL34-R37))
* Updated the `ManuscriptRecordController` to use `Auth::id()` instead of `auth()->id()` for consistency.
* Added a new migration file to update the `manuscript_records` table with the new fields and renamed the existing field.

### Frontend Changes:
* Updated `QuestionEditor.vue` to include a new `hideEditor` prop and conditionally render the editor based on this prop. [[1]](diffhunk://#diff-e5e3143669087594af29c0d8d9b7fddad1675f7cd1b4a1c31bc508e67d9b2508R13-R19) [[2]](diffhunk://#diff-e5e3143669087594af29c0d8d9b7fddad1675f7cd1b4a1c31bc508e67d9b2508R71)
* Modified `ManuscriptRecordFormView.vue` to include the new fields and validation rules, and updated the event names for consistency. [[1]](diffhunk://#diff-d0d32f4aafd46954fb5f533f8cf2b9261475c1948e38a9d01cb0b428f77e84aeL3-R36) [[2]](diffhunk://#diff-d0d32f4aafd46954fb5f533f8cf2b9261475c1948e38a9d01cb0b428f77e84aeR81-R85) [[3]](diffhunk://#diff-d0d32f4aafd46954fb5f533f8cf2b9261475c1948e38a9d01cb0b428f77e84aeL93-R109) [[4]](diffhunk://#diff-d0d32f4aafd46954fb5f533f8cf2b9261475c1948e38a9d01cb0b428f77e84aeL131-R142) [[5]](diffhunk://#diff-d0d32f4aafd46954fb5f533f8cf2b9261475c1948e38a9d01cb0b428f77e84aeL249-R255) [[6]](diffhunk://#diff-d0d32f4aafd46954fb5f533f8cf2b9261475c1948e38a9d01cb0b428f77e84aeL501-R507) [[7]](diffhunk://#diff-d0d32f4aafd46954fb5f533f8cf2b9261475c1948e38a9d01cb0b428f77e84aeR535-R571)
* Added new localization strings for the new fields and updated existing ones in both English and French localization files. [[1]](diffhunk://#diff-f41d834e4b61f15e83c95823f1fa33d2eaf43bdf4ff3a93def46793f9011810aL522-R527) [[2]](diffhunk://#diff-418711763e6501955b074eea5a0b626108b1b08b203a3ee2856a9bf35f4c8f08L522-R527)

### Testing:
* Added a new test to ensure that a user cannot submit their manuscript for review without providing an explanation if they do not want to apply for an OGL.