### PR TITLE
feat: add localization for manuscript peer reviewer dialog

### DIFF
--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -767,5 +767,8 @@
   },
   "mannage-peer-review": {
     "delete-peer-reviewer": "Delete Peer Reviewer"
+  },
+  "manuscript-peer-review-dialog": {
+    "title": "Add a peer reviewer for this manuscript"
   }
 }

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -767,5 +767,8 @@
   },
   "mannage-peer-review": {
     "delete-peer-reviewer": "Supprimer l'évaluateur"
+  },
+  "manuscript-peer-review-dialog": {
+    "title": "Ajouter un évaluateur pour ce manuscrit"
   }
 }

--- a/resources/src/models/ManuscriptPeerReviewer/components/AddManuscriptPeerReviewerDialog.vue
+++ b/resources/src/models/ManuscriptPeerReviewer/components/AddManuscriptPeerReviewerDialog.vue
@@ -40,7 +40,7 @@ async function addManuscriptPeerReviewer() {
 </script>
 
 <template>
-  <BaseDialog :title="$t('manuscript-author-dialog.title')">
+  <BaseDialog :title="$t('manuscript-peer-review-dialog.title')">
     <q-form @submit="addManuscriptPeerReviewer">
       <div
         class="q-mx-md q-mt-lg text-body1 text-primary text-weight-medium"
@@ -53,6 +53,7 @@ async function addManuscriptPeerReviewer() {
       <AuthorSelect
         v-model="authorId"
         class="q-ma-md"
+        :label="$t('common.reviewer')"
         :disabled-author-ids="disabledAuthorIds"
         :rules="[(val: number|null) => val !== null || t('common.required')]"
       />


### PR DESCRIPTION
This pull request includes changes to add localization for a new peer reviewer dialog and update the related Vue component to use the new localization strings. The most important changes include adding new localization entries in both English and French, and updating the title and label in the `AddManuscriptPeerReviewerDialog` component.

Localization updates:

* [`resources/src/locales/en.json`](diffhunk://#diff-f41d834e4b61f15e83c95823f1fa33d2eaf43bdf4ff3a93def46793f9011810aR770-R772): Added the `"manuscript-peer-review-dialog"` entry with the title for adding a peer reviewer.
* [`resources/src/locales/fr.json`](diffhunk://#diff-418711763e6501955b074eea5a0b626108b1b08b203a3ee2856a9bf35f4c8f08R770-R772): Added the `"manuscript-peer-review-dialog"` entry with the title for adding a peer reviewer in French.

Component updates:

* [`resources/src/models/ManuscriptPeerReviewer/components/AddManuscriptPeerReviewerDialog.vue`](diffhunk://#diff-73ab2bdc830443818b5e62a02b92355e3313ab6ccc4d8735bc9bf177834c0b27L43-R43): Updated the dialog title to use the new localization string for the peer reviewer dialog.
* [`resources/src/models/ManuscriptPeerReviewer/components/AddManuscriptPeerReviewerDialog.vue`](diffhunk://#diff-73ab2bdc830443818b5e62a02b92355e3313ab6ccc4d8735bc9bf177834c0b27R56): Added a label for the `AuthorSelect` component using the new localization string for "reviewer".