### PR TITLE
fix: update internal mrf form language and align button behaviour

### DIFF
--- a/app/Http/Controllers/ManuscriptRecordController.php
+++ b/app/Http/Controllers/ManuscriptRecordController.php
@@ -75,7 +75,7 @@ class ManuscriptRecordController extends Controller
             'relevant_to' => 'nullable|string',
             'public_interest_information' => 'nullable|string',
             'potential_public_interest' => 'boolean',
-            'do_not_apply_ogl' => 'boolean',
+            'apply_ogl' => 'boolean',
             'no_ogl_explanation' => 'nullable|string',
         ]);
 

--- a/app/Http/Resources/ManuscriptRecordResource.php
+++ b/app/Http/Resources/ManuscriptRecordResource.php
@@ -33,7 +33,7 @@ class ManuscriptRecordResource extends JsonResource
                 'relevant_to' => $this->relevant_to ?? '',
                 'potential_public_interest' => $this->potential_public_interest,
                 'public_interest_information' => $this->public_interest_information ?? '',
-                'do_not_apply_ogl' => $this->do_not_apply_ogl,
+                'apply_ogl' => $this->apply_ogl,
                 'no_ogl_explanation' => $this->no_ogl_explanation ?? '',
 
                 // dates and times

--- a/app/Models/ManuscriptRecord.php
+++ b/app/Models/ManuscriptRecord.php
@@ -51,7 +51,7 @@ class ManuscriptRecord extends Model implements Fundable, HasMedia
         'type' => ManuscriptRecordType::class,
         'status' => ManuscriptRecordStatus::class,
         'potential_public_interest' => 'boolean',
-        'do_not_apply_ogl' => 'boolean',
+        'apply_ogl' => 'boolean',
     ];
 
     // default values for optional fields
@@ -244,7 +244,7 @@ class ManuscriptRecord extends Model implements Fundable, HasMedia
             'region_id' => 'required|exists:regions,id',
             'functional_area_id' => 'required|exists:functional_areas,id',
             'relevant_to' => 'required',
-            'no_ogl_explanation' => 'required_if:do_not_apply_ogl,true',
+            'no_ogl_explanation' => 'required_if:apply_ogl,false',
         ]);
 
         $validator->after(function ($validator) {

--- a/database/migrations/2024_11_14_184759_add_ogl_question_to_manuscript_records_table.php
+++ b/database/migrations/2024_11_14_184759_add_ogl_question_to_manuscript_records_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('manuscript_records', function (Blueprint $table) {
-            $table->boolean('do_not_apply_ogl')->default(false);
+            $table->boolean('apply_ogl')->default(true);
             $table->text('no_ogl_explanation')->nullable();
             $table->renameColumn('additional_information', 'public_interest_information');
         });

--- a/resources/src/components/QuestionEditor.vue
+++ b/resources/src/components/QuestionEditor.vue
@@ -55,6 +55,12 @@ function onPaste(e: ClipboardEvent) {
   })
   editor.value?.runCmd('insertHTML', cleanText)
 }
+
+watch(value, (newValue) => {
+  if (newValue === '<br>') {
+    value.value = ''
+  }
+})
 </script>
 
 <template>

--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -522,7 +522,7 @@
     "working-title-text": "Enter to the manuscript's working title. You will be able to modify the title when you update this manuscript status to published.",
     "functional-area-text": "In order to improve reporting on research outputs, please select the relevant functional area for this manuscript.",
     "no-ogl-explanation": "Report Licensing",
-    "no-ogl-explanation-text-field-text": "DFO is committed to the \"Open by Design and by Default\" principle of Open Science, ensuring that all DFO publications are made available under the latest version of the \"Open Government Licence - Canada\" whenever possible. The Open Government Licence - Canada should not be applied if there are conflicting Licensing obligations.",
+    "no-ogl-explanation-text-field-text": "DFO is committed to the \"Open by Design and by Default\" principle of Open Science, ensuring that all DFO publications are made available under the latest version of the \"{url}\" whenever possible. The Open Government Licence - Canada should not be applied if there are conflicting Licensing obligations.",
     "ogl-link": "Open Government Licence - Canada",
     "apply_ogl": "Should this report be licensed under the Open Government Licence - Canada?",
     "ogl-provide-explanation": "Since you answered \"No,\" please provide an explanation of why an Open Government License cannot be applied to your report."

--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -522,10 +522,10 @@
     "working-title-text": "Enter to the manuscript's working title. You will be able to modify the title when you update this manuscript status to published.",
     "functional-area-text": "In order to improve reporting on research outputs, please select the relevant functional area for this manuscript.",
     "no-ogl-explanation": "Report Licensing",
-    "no-ogl-explanation-text-field-text": "DFO is committed to the \"Open by Design and by Default\" principle of Open Science, which means that all DFO publications will be published under the latest version of the \"{url}\" Are there any specific reasons or concerns that would prevent your report from being licensed under this Open Government Licence?",
+    "no-ogl-explanation-text-field-text": "DFO is committed to the \"Open by Design and by Default\" principle of Open Science, ensuring that all DFO publications are made available under the latest version of the \"Open Government Licence - Canada\" whenever possible. The Open Government Licence - Canada should not be applied if there are conflicting Licensing obligations.",
     "ogl-link": "Open Government Licence - Canada",
-    "do_not_apply_ogl": "We have reasons not to apply an open license for this report.",
-    "ogl-provide-explanation": "Since you answered \"yes,\" please provide an explanation of why an open license cannot be applied to your report."
+    "apply_ogl": "Should this report be licensed under the Open Government Licence - Canada?",
+    "ogl-provide-explanation": "Since you answered \"No,\" please provide an explanation of why an Open Government License cannot be applied to your report."
   },
   "my-manuscript-records": {
     "actions-still-required": "Actions still required",

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -521,11 +521,11 @@
     "upload-text": "Téléchargez la copie la plus récente de votre manuscrit au format PDF. \nCe fichier peut être mis à jour selon les besoins du demandeur, même après la soumission du manuscrit.",
     "working-title-text": "Entrez le titre provisoir du manuscrit. \nVous pourrez modifier le titre lorsque vous mettrez à jour le statut de ce manuscrit à publié.",
     "functional-area-text": "Afin d'améliorer les rapports sur les résultats de la recherche, veuillez sélectionner le domaine fonctionnel pertinent pour ce manuscrit.",
-    "no-ogl-explanation-text-field-text": "Le MPO s'engage à suivre le principe « ouvert par conception et par défaut » de la science ouverte. Par conséquent, toutes les publications du MPO seront publiées sous la dernière version de la « {url} ». Avez-vous des raisons de croire que votre rapport ne devrait pas être licencié sous cette licence du gouvernement ouvert?",
+    "no-ogl-explanation-text-field-text": "MPO s’engage envers le principe de « Ouvert par conception et par défaut » de la science ouverte, en s’assurant que toutes les publications du MPO soient mises à disposition sous la dernière version de la « Licence du gouvernement ouvert - Canada » dans la mesure du possible. La Licence du gouvernement ouvert - Canada ne doit pas être appliquée s’il existe des obligations de licence conflictuelles.",
     "ogl-link": "Licence du gouvernement ouvert – Canada",
-    "do_not_apply_ogl": "Nous avons des raisons de ne pas appliquer une licence ouverte pour ce rapport.",
+    "apply_ogl": "Ce rapport devrait-il être licencié sous la Licence du gouvernement ouvert - Canada ?",
     "no-ogl-explanation": "Licence de rapport",
-    "ogl-provide-explanation": "Puisque vous avez répondu « oui », veuillez expliquer pourquoi une licence ouverte ne peut pas être appliquée à votre rapport."
+    "ogl-provide-explanation": "Puisque vous avez répondu « Non », veuillez fournir une explication des raisons pour lesquelles une Licence du gouvernement ouvert ne peut pas être appliquée à votre rapport."
   },
   "my-manuscript-records": {
     "actions-still-required": "Actions encore nécessaires",

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -521,7 +521,7 @@
     "upload-text": "Téléchargez la copie la plus récente de votre manuscrit au format PDF. \nCe fichier peut être mis à jour selon les besoins du demandeur, même après la soumission du manuscrit.",
     "working-title-text": "Entrez le titre provisoir du manuscrit. \nVous pourrez modifier le titre lorsque vous mettrez à jour le statut de ce manuscrit à publié.",
     "functional-area-text": "Afin d'améliorer les rapports sur les résultats de la recherche, veuillez sélectionner le domaine fonctionnel pertinent pour ce manuscrit.",
-    "no-ogl-explanation-text-field-text": "MPO s’engage envers le principe de « Ouvert par conception et par défaut » de la science ouverte, en s’assurant que toutes les publications du MPO soient mises à disposition sous la dernière version de la « Licence du gouvernement ouvert - Canada » dans la mesure du possible. La Licence du gouvernement ouvert - Canada ne doit pas être appliquée s’il existe des obligations de licence conflictuelles.",
+    "no-ogl-explanation-text-field-text": "MPO s’engage envers le principe de « Ouvert par conception et par défaut » de la science ouverte, en s’assurant que toutes les publications du MPO soient mises à disposition sous la dernière version de la « {url} » dans la mesure du possible. La Licence du gouvernement ouvert - Canada ne doit pas être appliquée s’il existe des obligations de licence conflictuelles.",
     "ogl-link": "Licence du gouvernement ouvert – Canada",
     "apply_ogl": "Ce rapport devrait-il être licencié sous la Licence du gouvernement ouvert - Canada ?",
     "no-ogl-explanation": "Licence de rapport",

--- a/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
+++ b/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
@@ -48,7 +48,7 @@ export interface ManuscriptRecord extends BaseManuscriptRecord {
   relevant_to: string
   potential_public_interest: boolean
   public_interest_information: string
-  do_not_apply_ogl: boolean
+  apply_ogl: boolean
   no_ogl_explanation: string
   readonly sent_for_review_at: string | null
   readonly reviewed_at: string | null

--- a/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
+++ b/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
@@ -83,7 +83,7 @@ const generalSectionStatus = computed(() => {
     return 'error'
 
   if (manuscript.type === 'secondary') {
-    if (manuscript.no_ogl_explanation === '' && manuscript.do_not_apply_ogl)
+    if (manuscript.no_ogl_explanation === '' && manuscript.apply_ogl)
       return 'incomplete'
   }
 
@@ -551,7 +551,7 @@ async function generatePLS() {
             :title="$t('mrf.no-ogl-explanation')"
             :disable="loading"
             :readonly="isManuscriptReadOnly"
-            :hide-editor="!manuscriptResource.data.do_not_apply_ogl"
+            :hide-editor="manuscriptResource.data.apply_ogl"
             required
             class="q-mb-md"
           >
@@ -569,16 +569,16 @@ async function generatePLS() {
               </template>
             </i18n-t>
             <div class="text-body2 text-primary text-weight-medium">
-              {{ $t('mrf.do_not_apply_ogl') }}
+              {{ $t('mrf.apply_ogl') }}
             </div>
             <YesNoBooleanOptionGroup
               v-model="
                 manuscriptResource.data
-                  .do_not_apply_ogl
+                  .apply_ogl
               "
               class="q-mb-md"
             />
-            <p v-if="manuscriptResource.data.do_not_apply_ogl">
+            <p v-if="!manuscriptResource.data.apply_ogl">
               {{ $t('mrf.ogl-provide-explanation') }}
             </p>
           </QuestionEditor>

--- a/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
+++ b/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
@@ -536,6 +536,7 @@ async function generatePLS() {
                   .potential_public_interest
               "
               class="q-mb-md"
+              :disable="isManuscriptReadOnly"
             />
             <p>
               {{
@@ -577,6 +578,7 @@ async function generatePLS() {
                   .apply_ogl
               "
               class="q-mb-md"
+              :disable="isManuscriptReadOnly"
             />
             <p v-if="!manuscriptResource.data.apply_ogl">
               {{ $t('mrf.ogl-provide-explanation') }}

--- a/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
+++ b/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
@@ -83,7 +83,7 @@ const generalSectionStatus = computed(() => {
     return 'error'
 
   if (manuscript.type === 'secondary') {
-    if (manuscript.no_ogl_explanation === '' && manuscript.apply_ogl)
+    if (manuscript.no_ogl_explanation === '' && !manuscript.apply_ogl)
       return 'incomplete'
   }
 

--- a/tests/Feature/Models/ManuscriptRecordTest.php
+++ b/tests/Feature/Models/ManuscriptRecordTest.php
@@ -272,7 +272,7 @@ test('a user can mark their manuscript as submitted', function () {
 
 test('a user cannot submit their manuscript for review if they do not want an OGL but have provide no explanation', function () {
     $manuscript = ManuscriptRecord::factory()->filled()->create([
-        'do_not_apply_ogl' => true,
+        'apply_ogl' => false,
     ]);
 
     $this->actingAs($manuscript->user)->putJson("/api/manuscript-records/{$manuscript->id}/submit-for-review", [


### PR DESCRIPTION
This pull request includes updates to the `ManuscriptRecord` model and its related components, controllers, and resources which manage the `do_not_apply_ogl` variable. These updates reflect the change in language to the *Report Licensing* question found within the DFO Publication MRF form.  

### Frontend Changes
- Clarification of the *Report Licensing* description and question. The question now prompts for a positive answer for application of the OGL in English and French locales.
- *Report Licensing* toggle button now defaults to "Yes".

### Backend Changes
- Existing field `do_not_apply_ogl` updated to `apply_ogl` to reflect the new behaviour of the question.
- Default boolean for `apply_ogl` in `add_ogl_question_to_manuscript_records_table` switched to True.

### Testing
- Boolean swapped in `ManuscriptRecordTest` to False reflect change in context of `apply_ogl`.  