### PR TITLE
feat(librarium): added custom email domain rule and user email editing

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -4,8 +4,10 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\UserResource\Pages;
 use App\Models\User;
+use App\Rules\AuthorizeEmailDomain;
 use Filament\Facades\Filament;
 use Filament\Forms;
+use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
@@ -27,26 +29,35 @@ class UserResource extends Resource
                     ->Filled()
                     ->required(),
                 Forms\Components\TextInput::make('last_name')
-                    ->disabledOn('edit')
-                    ->Filled(),
-                Forms\Components\TextInput::make('email')
-                    ->disabledOn('edit')
-                    ->Filled(),
+					  ->disabledOn('edit')
+					  ->Filled(),
                 Forms\Components\Section::make([
-                    Forms\Components\CheckboxList::make('roles')
-                        ->relationship(titleAttribute: 'name')
-                        ->default(['1'])
-                        ->options([
-                            '3' => 'Admin',
-                            '2' => 'Director',
-                        ]),
-                ]),
-            ]);
+		    Forms\Components\TextInput::make('email')
+					      ->Filled()
+					      ->rules(['required', 'string', 'email', new AuthorizeEmailDomain()]),
+		    Forms\Components\Actions::make([
+			Forms\Components\Actions\Action::make('email_verified_at')
+						       ->action(function (Forms\Get $get, Forms\Set $set) {
+							   $set('email_verified_at', false);
+						       }
+						       )
+			]
+							   ),
+
+		    Forms\Components\CheckboxList::make('roles')
+						 ->relationship(titleAttribute: 'name')
+						 ->default(['1'])
+						 ->options([
+						     '3' => 'Admin',
+						     '2' => 'Director',
+						 ]),
+		]),
+	    ]);
     }
 
     public static function table(Table $table): Table
     {
-        return $table
+	return $table
             ->columns([
                 Tables\Columns\TextColumn::make('first_name')
                     ->sortable(),
@@ -69,35 +80,59 @@ class UserResource extends Resource
                     ->searchable(isIndividual: true),
             ])
             ->filters([
-                //
-            ])
-            ->actions([
-                Tables\Actions\EditAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    // Placeholder
-                ]),
-            ])
-            ->defaultSort('first_name');
+		Tables\Filters\TernaryFilter::make('email_verified_at')
+					    ->label('Verified')
+					    ->nullable()
+					    ->placeholder('All'),
+                Tables\Filters\SelectFilter::make('active')
+					   ->options([
+					       true => 'Active',
+					       false => 'Inactive',
+					   ]),
+		Tables\Filters\Filter::make('no_roles')
+				     ->label('No Roles')
+				     ->query(fn ($query) => $query->whereDoesntHave('roles')),
+		Tables\Filters\Filter::make('author')
+				     ->label('Author')
+				     ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'author'))),
+
+		Tables\Filters\Filter::make('director')
+				     ->label('Director')
+				     ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'director'))),
+
+		Tables\Filters\Filter::make('admin')
+				     ->label('Admin')
+				     ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'admin'))),
+
+	    ])
+	    ->actions([
+		Tables\Actions\EditAction::make(),
+	    ])
+	    ->bulkActions([
+		Tables\Actions\BulkActionGroup::make([
+		    // Placeholder
+		]),
+	    ])
+	    ->defaultSort('first_name');
     }
 
+    
     public static function getRelations(): array
     {
-        return [
-            //
-        ];
+	return [
+	    //
+	];
     }
 
     public static function getPages(): array
     {
-        //	$user = Filament::auth()->user();
-        //	Gate::authorize('updateAnyUser', $user);
+	//	$user = Filament::auth()->user();
+	//	Gate::authorize('updateAnyUser', $user);
 
-        return [
-            'index' => Pages\ListUsers::route('/'),
-            'create' => Pages\CreateUser::route('/create'),
-            'edit' => Pages\EditUser::route('/{record}/edit'),
-        ];
+	return [
+	    'index' => Pages\ListUsers::route('/'),
+	    'create' => Pages\CreateUser::route('/create'),
+	    'edit' => Pages\EditUser::route('/{record}/edit'),
+	];
     }
 }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -35,15 +35,6 @@ class UserResource extends Resource
 		    Forms\Components\TextInput::make('email')
 					      ->Filled()
 					      ->rules(['required', 'string', 'email', new AuthorizeEmailDomain()]),
-		    Forms\Components\Actions::make([
-			Forms\Components\Actions\Action::make('email_verified_at')
-						       ->action(function (Forms\Get $get, Forms\Set $set) {
-							   $set('email_verified_at', false);
-						       }
-						       )
-			]
-							   ),
-
 		    Forms\Components\CheckboxList::make('roles')
 						 ->relationship(titleAttribute: 'name')
 						 ->default(['1'])

--- a/app/Rules/AuthorizeEmailDomain.php
+++ b/app/Rules/AuthorizeEmailDomain.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Rules;
+
+use App\Http\Controllers\Auth\Traits\AuthorizedDomainTrait;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class AuthorizeEmailDomain implements ValidationRule
+{
+    use AuthorizedDomainTrait;
+
+
+    /**
+     * Determine if the email is a valid domain.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param Closure $fail
+     * @return Closure
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $this->isEmailDomainAllowed($value)) {
+	        $fail('The email domain is not allowed.');
+	}
+    }
+}
+


### PR DESCRIPTION
This pull request includes updates to the Librarium `UserResource` file and the creation of a new custom rule. These changes allow for support staff to edit an existing user's email address but ensure that the email domain is in the allow-list.

### Frontend Changes
- User Edit Form in the Librarium support panel now shows Email as an editable attribute.
- Trying to save an Email that's domain is not in the allow-list will throw an error.

### Backend Changes
-  A new custom rule `AuthorizeEmailDomain` has been created based upon the logic found in the `AuthorizedDomainTrait`.
- This new rule simplifies validating an email domain against the allow-list in the context of the Librarium support panel.
- Librarium will not save or apply changes to a user's email whose domain is not in the allow list.