### PR TITLE
refactor(librarium): updated roles edit and filter to respond dynamically to a change in roles

### DIFF
--- a/app/Enums/Permissions/UserRole.php
+++ b/app/Enums/Permissions/UserRole.php
@@ -2,7 +2,9 @@
 
 namespace App\Enums\Permissions;
 
-enum UserRole: string
+use Filament\Support\Contracts\HasLabel;
+
+enum UserRole: string implements HasLabel
 {
     case AUTHOR = 'author';
     case DIRECTOR = 'director';
@@ -35,7 +37,7 @@ enum UserRole: string
         };
     }
 
-    public function label(): string
+    public function getLabel(): string
     {
         return match ($this) {
             self::AUTHOR => 'Author',

--- a/app/Enums/Permissions/UserRole.php
+++ b/app/Enums/Permissions/UserRole.php
@@ -2,9 +2,7 @@
 
 namespace App\Enums\Permissions;
 
-use Filament\Support\Contracts\HasLabel;
-
-enum UserRole: string implements HasLabel
+enum UserRole: string 
 {
     case AUTHOR = 'author';
     case DIRECTOR = 'director';
@@ -37,7 +35,7 @@ enum UserRole: string implements HasLabel
         };
     }
 
-    public function getLabel(): string
+    public function label(): string
     {
         return match ($this) {
             self::AUTHOR => 'Author',

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -8,7 +8,6 @@ use App\Models\User;
 use App\Rules\AuthorizeEmailDomain;
 use Filament\Facades\Filament;
 use Filament\Forms;
-use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
@@ -26,105 +25,104 @@ class UserResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('first_name')
-					  ->disabledOn('edit')
-					  ->Filled()
-					  ->required(),
+                    ->disabledOn('edit')
+                    ->Filled()
+                    ->required(),
                 Forms\Components\TextInput::make('last_name')
-					  ->disabledOn('edit')
-					  ->Filled(),
+                    ->disabledOn('edit')
+                    ->Filled(),
                 Forms\Components\Section::make([
-		    Forms\Components\TextInput::make('email')
-					      ->Filled()
-					      ->rules(['required', 'string', 'email', new AuthorizeEmailDomain()]),
-		    Forms\Components\CheckboxList::make('roles')
-						 ->label('Roles')
-						 ->options(UserRole::class)
-						 ->afterStateHydrated(function ($component, $state) {
-						     // Prepopulate the roles based on what is passed from beforeFill()
-						     $component->state($state);
-						 })
-		]),
-	    ]);
+                    Forms\Components\TextInput::make('email')
+                        ->Filled()
+                        ->rules(['required', 'string', 'email', new AuthorizeEmailDomain]),
+                    Forms\Components\CheckboxList::make('roles')
+                        ->label('Roles')
+                        ->options(UserRole::class)
+                        ->afterStateHydrated(function ($component, $state) {
+                            // Prepopulate the roles based on what is passed from beforeFill()
+                            $component->state($state);
+                        }),
+                ]),
+            ]);
     }
 
     public static function table(Table $table): Table
     {
-	return $table
+        return $table
             ->columns([
                 Tables\Columns\TextColumn::make('first_name')
-					 ->sortable(),
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('last_name')
-					 ->sortable(),
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('email'),
                 Tables\Columns\IconColumn::make('email_verified_at')
-					 ->boolean()
-					 ->sortable(),
+                    ->boolean()
+                    ->sortable(),
                 Tables\Columns\IconColumn::make('active')
-					 ->boolean()
-					 ->sortable(),
+                    ->boolean()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('roles.name')
-					 ->badge()
-					 ->color(fn (string $state): string => match ($state) {
-					     'author' => 'success',
-					     'director' => 'warning',
-					     'admin' => 'danger',
-					 })
-					 ->searchable(isIndividual: true),
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'author' => 'success',
+                        'director' => 'warning',
+                        'admin' => 'danger',
+                    })
+                    ->searchable(isIndividual: true),
             ])
             ->filters([
-		Tables\Filters\TernaryFilter::make('email_verified_at')
-					    ->label('Verified')
-					    ->nullable()
-					    ->placeholder('All'),
-                Tables\Filters\SelectFilter::make('active')
-					   ->options([
-					       true => 'Active',
-					       false => 'Inactive',
-					   ]),
-		Tables\Filters\Filter::make('no_roles')
-				     ->label('No Roles')
-				     ->query(fn ($query) => $query->whereDoesntHave('roles')),
-		Tables\Filters\Filter::make('author')
-				     ->label('Author')
-				     ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'author'))),
+            Tables\Filters\TernaryFilter::make('email_verified_at')
+                    ->label('Verified')
+                    ->nullable()
+                    ->placeholder('All'),
+            Tables\Filters\SelectFilter::make('active')
+                    ->options([
+                        true => 'Active',
+                        false => 'Inactive',
+                    ]),
+            Tables\Filters\Filter::make('no_roles')
+                    ->label('No Roles')
+                    ->query(fn ($query) => $query->whereDoesntHave('roles')),
+            Tables\Filters\Filter::make('author')
+                    ->label('Author')
+                    ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'author'))),
 
-		Tables\Filters\Filter::make('director')
-				     ->label('Director')
-				     ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'director'))),
+            Tables\Filters\Filter::make('director')
+                    ->label('Director')
+                    ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'director'))),
 
-		Tables\Filters\Filter::make('admin')
-				     ->label('Admin')
-				     ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'admin'))),
+            Tables\Filters\Filter::make('admin')
+                    ->label('Admin')
+                    ->query(fn ($query) => $query->whereHas('roles', fn ($query) => $query->where('name', 'admin'))),
 
-	    ])
-	    ->actions([
-		Tables\Actions\EditAction::make(),
-	    ])
-	    ->bulkActions([
-		Tables\Actions\BulkActionGroup::make([
-		    // Placeholder
-		]),
-	    ])
-	    ->defaultSort('first_name');
+        ])
+            ->actions([
+            Tables\Actions\EditAction::make(),
+        ])
+            ->bulkActions([
+            Tables\Actions\BulkActionGroup::make([
+                    // Placeholder
+            ]),
+        ])
+            ->defaultSort('first_name');
     }
 
-    
     public static function getRelations(): array
     {
-	return [
-	    //
-	];
+        return [
+            //
+        ];
     }
 
     public static function getPages(): array
     {
-	//	$user = Filament::auth()->user();
-	//	Gate::authorize('updateAnyUser', $user);
+        //	$user = Filament::auth()->user();
+        //	Gate::authorize('updateAnyUser', $user);
 
-	return [
-	    'index' => Pages\ListUsers::route('/'),
-	    'create' => Pages\CreateUser::route('/create'),
-	    'edit' => Pages\EditUser::route('/{record}/edit'),
-	];
+        return [
+            'index' => Pages\ListUsers::route('/'),
+            'create' => Pages\CreateUser::route('/create'),
+            'edit' => Pages\EditUser::route('/{record}/edit'),
+        ];
     }
 }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\Permissions\UserRole;
 use App\Filament\Resources\UserResource\Pages;
 use App\Models\User;
 use App\Rules\AuthorizeEmailDomain;
@@ -25,9 +26,9 @@ class UserResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('first_name')
-                    ->disabledOn('edit')
-                    ->Filled()
-                    ->required(),
+					  ->disabledOn('edit')
+					  ->Filled()
+					  ->required(),
                 Forms\Components\TextInput::make('last_name')
 					  ->disabledOn('edit')
 					  ->Filled(),
@@ -36,12 +37,12 @@ class UserResource extends Resource
 					      ->Filled()
 					      ->rules(['required', 'string', 'email', new AuthorizeEmailDomain()]),
 		    Forms\Components\CheckboxList::make('roles')
-						 ->relationship(titleAttribute: 'name')
-						 ->default(['1'])
-						 ->options([
-						     '3' => 'Admin',
-						     '2' => 'Director',
-						 ]),
+						 ->label('Roles')
+						 ->options(UserRole::class)
+						 ->afterStateHydrated(function ($component, $state) {
+						     // Prepopulate the roles based on what is passed from beforeFill()
+						     $component->state($state);
+						 })
 		]),
 	    ]);
     }
@@ -51,24 +52,24 @@ class UserResource extends Resource
 	return $table
             ->columns([
                 Tables\Columns\TextColumn::make('first_name')
-                    ->sortable(),
+					 ->sortable(),
                 Tables\Columns\TextColumn::make('last_name')
-                    ->sortable(),
+					 ->sortable(),
                 Tables\Columns\TextColumn::make('email'),
                 Tables\Columns\IconColumn::make('email_verified_at')
-                    ->boolean()
-                    ->sortable(),
+					 ->boolean()
+					 ->sortable(),
                 Tables\Columns\IconColumn::make('active')
-                    ->boolean()
-                    ->sortable(),
+					 ->boolean()
+					 ->sortable(),
                 Tables\Columns\TextColumn::make('roles.name')
-                    ->badge()
-                    ->color(fn (string $state): string => match ($state) {
-                        'author' => 'success',
-                        'director' => 'warning',
-                        'admin' => 'danger',
-                    })
-                    ->searchable(isIndividual: true),
+					 ->badge()
+					 ->color(fn (string $state): string => match ($state) {
+					     'author' => 'success',
+					     'director' => 'warning',
+					     'admin' => 'danger',
+					 })
+					 ->searchable(isIndividual: true),
             ])
             ->filters([
 		Tables\Filters\TernaryFilter::make('email_verified_at')

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -17,11 +17,6 @@ class EditUser extends EditRecord
         ];
     }
 
-    protected function beforeFill(): void
-    {
-        $this->data['roles'] = $this->record->roles->pluck('name')->toArray();
-    }
-
     /**
      * Get the URL to redirect to after performing an action in the EditUser page.
      *

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -16,7 +16,13 @@ class EditUser extends EditRecord
             Actions\DeleteAction::make(),
         ];
     }
+    
 
+    protected function beforeFill(): void
+    {
+	$this->data['roles'] = $this->record->roles->pluck('name')->toArray();
+    }
+    
     /**
      * Get the URL to redirect to after performing an action in the EditUser page.
      *

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -16,13 +16,12 @@ class EditUser extends EditRecord
             Actions\DeleteAction::make(),
         ];
     }
-    
 
     protected function beforeFill(): void
     {
-	$this->data['roles'] = $this->record->roles->pluck('name')->toArray();
+        $this->data['roles'] = $this->record->roles->pluck('name')->toArray();
     }
-    
+
     /**
      * Get the URL to redirect to after performing an action in the EditUser page.
      *

--- a/app/Rules/AuthorizeEmailDomain.php
+++ b/app/Rules/AuthorizeEmailDomain.php
@@ -10,20 +10,15 @@ class AuthorizeEmailDomain implements ValidationRule
 {
     use AuthorizedDomainTrait;
 
-
     /**
      * Determine if the email is a valid domain.
      *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param Closure $fail
      * @return Closure
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! $this->isEmailDomainAllowed($value)) {
-	        $fail('The email domain is not allowed.');
-	}
+            $fail('The email domain is not allowed.');
+        }
     }
 }
-


### PR DESCRIPTION
This pull request includes updates to the Librarium `UserResource` file to decouple the Roles filter and edit methods. A general tidy of the code was done too.

### Frontend Changes
- The View Table filter now displays available roles in a drop-down, mono-Select component.
- The Edit User form now displays available roles in a two-column Checkbox component.
- The search bar above the *Roles* column in the View Table has been removed.
- You can now search by First Name, Last Name, Email, or Role in the global search bar.

### Backend Changes
- New roles which have not been assigned a badge color will default to Blue.
- The Roles filter has been changed from Checkbox to Select. This allows for the Select option to automatically change when there is a change to the Roles table.
- Unused code has been removed.