### PR TITLE
revert: reduce max character limit for role title and department name…

### DIFF
--- a/app/Http/Controllers/AuthorEmploymentController.php
+++ b/app/Http/Controllers/AuthorEmploymentController.php
@@ -33,8 +33,8 @@ class AuthorEmploymentController extends Controller
 
         $validated = $request->validate([
             'organization_id' => 'nullable|exists:organizations,id',
-            'role_title' => 'nullable|string|max:125',
-            'department_name' => 'nullable|string|max:125',
+            'role_title' => 'nullable|string|max:50',
+            'department_name' => 'nullable|string|max:50',
             'start_date' => 'required|date',
             'end_date' => 'nullable|date',
         ]);
@@ -81,8 +81,8 @@ class AuthorEmploymentController extends Controller
         $this->authorize('update', $authorEmployment);
 
         $validated = $request->validate([
-            'role_title' => 'nullable|string|max:125',
-            'department_name' => 'nullable|string|max:125',
+            'role_title' => 'nullable|string|max:50',
+            'department_name' => 'nullable|string|max:50',
             'start_date' => 'required|date',
             'end_date' => 'nullable|date',
         ]);

--- a/resources/src/models/AuthorEmployment/components/AddAuthorEmploymentDialog.vue
+++ b/resources/src/models/AuthorEmployment/components/AddAuthorEmploymentDialog.vue
@@ -65,7 +65,7 @@ async function createAuthorEmployment() {
           :label="t('orcid-employment-edit.role-title')"
           outlined
           :rules="[(val: string|null) => !!val || t('common.required'),
-                   (val: string) => val.length <= 125 || t('common.validation.must-be-less-than-x-characters', [125]),
+                   (val: string) => val.length <= 50 || t('common.validation.must-be-less-than-x-characters', [50]),
           ]"
           class="q-mb-md"
         />
@@ -74,7 +74,7 @@ async function createAuthorEmployment() {
           :label="t('orcid-employment-edit.department-name')"
           outlined
           :rules="[(val: string|null) => !!val || t('common.required'),
-                   (val: string) => val.length <= 125 || t('common.validation.must-be-less-than-x-characters', [125]),
+                   (val: string) => val.length <= 50 || t('common.validation.must-be-less-than-x-characters', [50]),
           ]"
           class="q-mb-md"
           :hint="t('orcid-employment-edit.department-name-hint')"

--- a/resources/src/models/AuthorEmployment/components/EditAuthorEmploymentDialog.vue
+++ b/resources/src/models/AuthorEmployment/components/EditAuthorEmploymentDialog.vue
@@ -78,7 +78,7 @@ function deleteAuthorEmployment() {
           :label="t('orcid-employment-edit.role-title')"
           outlined
           :rules="[(val: string|null) => !!val || t('common.required'),
-                   (val: string) => val.length <= 125 || t('common.validation.must-be-less-than-x-characters', [125]),
+                   (val: string) => val.length <= 50 || t('common.validation.must-be-less-than-x-characters', [50]),
           ]"
           class="q-mb-md"
         />
@@ -87,7 +87,7 @@ function deleteAuthorEmployment() {
           :label="t('orcid-employment-edit.department-name')"
           outlined
           :rules="[(val: string|null) => !!val || t('common.required'),
-                   (val: string) => val.length <= 125 || t('common.validation.must-be-less-than-x-characters', [125]),
+                   (val: string) => val.length <= 50 || t('common.validation.must-be-less-than-x-characters', [50]),
           ]"
           class="q-mb-md"
           :hint="t('orcid-employment-edit.department-name-hint')"

--- a/tests/Feature/Models/AuthorEmployementTest.php
+++ b/tests/Feature/Models/AuthorEmployementTest.php
@@ -3,6 +3,7 @@
 use App\Models\AuthorEmployment;
 use App\Models\Organization;
 use App\Models\User;
+use Illuminate\Support\Facades\Queue;
 
 test('a user can list their author profile employements', function () {
     $user = User::factory()->create();
@@ -120,7 +121,7 @@ test('a user can delete an author employment record', function () {
 
 });
 
-test('adding a 125 char role title is valid', function () {
+test('adding a 50 char role title is valid', function () {
     $user = User::factory()->create();
     $employment = AuthorEmployment::factory()->create([
         'author_id' => $user->author->id,
@@ -132,11 +133,11 @@ test('adding a 125 char role title is valid', function () {
         'author_id' => $user->author->id,
         'organization_id' => Organization::getDefaultOrganization()->id,
         'start_date' => now()->subYear(),
-        'role_title' => str_repeat('a', 125),
+        'role_title' => str_repeat('a', 50),
     ])->toArray();
 
     $response = $this->actingAs($user)->putJson("api/authors/{$user->author->id}/employments/{$employment->id}", $data)->assertOk();
 
-    expect($response->json('data.role_title'))->toBe(str_repeat('a', 125));
+    expect($response->json('data.role_title'))->toBe(str_repeat('a', 50));
 
 });


### PR DESCRIPTION
Revert title and department back to 50 - currently ORCID will accept longer strings but it will look bad in the card and potentially overflow.

![image](https://github.com/user-attachments/assets/2c296148-e59d-451f-a3eb-373ccca7c8aa)
