### PR TITLE
feat(librarium): add activate and verify email actions

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -45,7 +45,7 @@ class UserResource extends Resource
                         Forms\Components\Toggle::make('active')
                             ->label('Activate User')
                             ->dehydrated(false)
-							->hidden(fn ($record) => $record && !$record->active)
+							->hidden(fn ($record) => $record && !$record->email_verified_at)
                             ->onColor('success'),
                         Forms\Components\Actions::make([
                             Forms\Components\Actions\Action::make('verify_email')

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -49,6 +49,7 @@ class UserResource extends Resource
                             ->onColor('success'),
                         Forms\Components\Actions::make([
                             Forms\Components\Actions\Action::make('verify_email')
+			    ->label('Activate & Verify')
                                 ->hidden(fn ($record) => $record && $record->email_verified_at)
                                 ->action('setVerifiedEmail'),
                         ]),

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -44,6 +44,7 @@ class UserResource extends Resource
                     ->schema([
                         Forms\Components\Toggle::make('active')
                             ->label('Activate User')
+                            ->dehydrated(false)
 							->hidden(fn ($record) => $record && !$record->active)
                             ->onColor('success'),
                         Forms\Components\Actions::make([

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -44,7 +44,6 @@ class UserResource extends Resource
                     ->schema([
                         Forms\Components\Toggle::make('active')
                             ->label('Activate User')
-                            ->dehydrated(false)
 							->hidden(fn ($record) => $record && !$record->active)
                             ->onColor('success'),
                         Forms\Components\Actions::make([

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -33,8 +33,10 @@ class UserResource extends Resource
                         ->Filled()
                         ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
                     Forms\Components\CheckboxList::make('roles')
-                        ->relationship(titleAttribute: 'name')
-                        ->label('Roles'),
+						 ->relationship(titleAttribute: 'name')
+						 ->label('Roles'),
+		    Forms\Components\Toggle::make('active')
+					   ->dehydrated(false),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -26,17 +26,31 @@ class UserResource extends Resource
                     ->Filled()
                     ->required(),
                 Forms\Components\TextInput::make('last_name')
-                    ->disabledOn('edit')
-                    ->Filled(),
-                Forms\Components\Section::make([
+					  ->disabledOn('edit')
+					  ->Filled(),
+		
+                Forms\Components\Section::make('User Information')
+		->schema([
                     Forms\Components\TextInput::make('email')
                         ->Filled()
                         ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
                     Forms\Components\CheckboxList::make('roles')
 						 ->relationship(titleAttribute: 'name')
 						 ->label('Roles'),
+		]),
+		
+		Forms\Components\Section::make('Available Actions')
+					->description('Actions are instantaneous and may disappear once applied!')
+		->schema([
 		    Forms\Components\Toggle::make('active')
-					   ->dehydrated(false),
+		    ->label('Activate User')
+					   ->dehydrated(false)
+		    ->onColor('success'),
+		    Forms\Components\Actions::make([
+			Forms\Components\Actions\Action::make('verify_email')
+						       ->hidden(fn ($record) => $record && $record->email_verified_at)
+						       ->action('setVerifiedEmail'),
+		    ]),
                 ]),
             ]);
     }
@@ -54,62 +68,65 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('email')
                     ->searchable(),
                 Tables\Columns\IconColumn::make('email_verified_at')
-                    ->boolean()
-                    ->sortable(),
-                Tables\Columns\IconColumn::make('active')
-                    ->boolean()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('roles.name')
-                    ->badge()
-                    ->color(fn (string $state): string => match ($state) {
-                        'author' => 'success',
-                        'director' => 'warning',
-                        'admin' => 'danger',
-                        'default' => 'info',
-                    })
-                    ->searchable(),
-            ])
-            ->filters([
-                Tables\Filters\TernaryFilter::make('email_verified_at')
-                    ->label('Verified')
-                    ->nullable()
-                    ->placeholder('All'),
-                Tables\Filters\SelectFilter::make('active')
-                    ->options([
-                        true => 'Active',
-                        false => 'Inactive',
-                    ]),
-                Tables\Filters\Filter::make('no_roles')
-                    ->label('No Roles')
-                    ->query(fn ($query) => $query->whereDoesntHave('roles')),
-                Tables\Filters\SelectFilter::make('roles')
-                    ->relationship('roles', 'name')
-                    ->label('Role'),
-            ])
-            ->actions([
-                Tables\Actions\EditAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    // Placeholder
-                ]),
-            ])
-            ->defaultSort('first_name');
+		->label('Email Verified')
+					 ->default('heroicon-o-x-circle')
+					 ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+					 ->color(fn ($state) => $state instanceof \DateTime  ? 'success' : 'danger')
+					 ->sortable(),
+		Tables\Columns\IconColumn::make('active')
+					 ->boolean()
+					 ->sortable(),
+		Tables\Columns\TextColumn::make('roles.name')
+					 ->badge()
+					 ->color(fn (string $state): string => match ($state) {
+					     'author' => 'success',
+					     'director' => 'warning',
+					     'admin' => 'danger',
+					     'default' => 'info',
+					 })
+					 ->searchable(),
+	    ])
+	    ->filters([
+		Tables\Filters\TernaryFilter::make('email_verified_at')
+					    ->label('Verified')
+					    ->nullable()
+					    ->placeholder('All'),
+		Tables\Filters\SelectFilter::make('active')
+					   ->options([
+					       true => 'Active',
+					       false => 'Inactive',
+					   ]),
+		Tables\Filters\Filter::make('no_roles')
+				     ->label('No Roles')
+				     ->query(fn ($query) => $query->whereDoesntHave('roles')),
+		Tables\Filters\SelectFilter::make('roles')
+					   ->relationship('roles','name')
+					   ->label('Role')
+	    ])
+	    ->actions([
+		Tables\Actions\EditAction::make(),
+	    ])
+	    ->bulkActions([
+		Tables\Actions\BulkActionGroup::make([
+		    // Placeholder
+		]),
+	    ])
+	    ->defaultSort('first_name');
     }
 
     public static function getRelations(): array
     {
-        return [
-            //
-        ];
+	return [
+	    //
+	];
     }
 
     public static function getPages(): array
     {
-        return [
-            'index' => Pages\ListUsers::route('/'),
-            'create' => Pages\CreateUser::route('/create'),
-            'edit' => Pages\EditUser::route('/{record}/edit'),
-        ];
+	return [
+	    'index' => Pages\ListUsers::route('/'),
+	    'create' => Pages\CreateUser::route('/create'),
+	    'edit' => Pages\EditUser::route('/{record}/edit'),
+	];
     }
 }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -45,6 +45,7 @@ class UserResource extends Resource
                         Forms\Components\Toggle::make('active')
                             ->label('Activate User')
                             ->dehydrated(false)
+							->hidden(fn ($record) => $record && !$record->active)
                             ->onColor('success'),
                         Forms\Components\Actions::make([
                             Forms\Components\Actions\Action::make('verify_email')

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -23,35 +23,35 @@ class UserResource extends Resource
             ->schema([
                 Forms\Components\TextInput::make('first_name')
                     ->disabledOn('edit')
-                    ->Filled()
+                    ->filled()
                     ->required(),
                 Forms\Components\TextInput::make('last_name')
-					  ->disabledOn('edit')
-					  ->Filled(),
-		
+                    ->disabledOn('edit')
+                    ->filled(),
+
                 Forms\Components\Section::make('User Information')
-		->schema([
-                    Forms\Components\TextInput::make('email')
-                        ->Filled()
-                        ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
-                    Forms\Components\CheckboxList::make('roles')
-						 ->relationship(titleAttribute: 'name')
-						 ->label('Roles'),
-		]),
-		
-		Forms\Components\Section::make('Available Actions')
-					->description('Actions are instantaneous and may disappear once applied!')
-		->schema([
-		    Forms\Components\Toggle::make('active')
-		    ->label('Activate User')
-					   ->dehydrated(false)
-		    ->onColor('success'),
-		    Forms\Components\Actions::make([
-			Forms\Components\Actions\Action::make('verify_email')
-						       ->hidden(fn ($record) => $record && $record->email_verified_at)
-						       ->action('setVerifiedEmail'),
-		    ]),
-                ]),
+                    ->schema([
+                        Forms\Components\TextInput::make('email')
+                            ->filled()
+                            ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
+                        Forms\Components\CheckboxList::make('roles')
+                            ->relationship(titleAttribute: 'name')
+                            ->label('Roles'),
+                    ]),
+
+                Forms\Components\Section::make('Available Actions')
+                    ->description('Actions are instantaneous and may disappear once applied!')
+                    ->schema([
+                        Forms\Components\Toggle::make('active')
+                            ->label('Activate User')
+                            ->dehydrated(false)
+                            ->onColor('success'),
+                        Forms\Components\Actions::make([
+                            Forms\Components\Actions\Action::make('verify_email')
+                                ->hidden(fn ($record) => $record && $record->email_verified_at)
+                                ->action('setVerifiedEmail'),
+                        ]),
+                    ]),
             ]);
     }
 
@@ -68,65 +68,65 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('email')
                     ->searchable(),
                 Tables\Columns\IconColumn::make('email_verified_at')
-		->label('Email Verified')
-					 ->default('heroicon-o-x-circle')
-					 ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
-					 ->color(fn ($state) => $state instanceof \DateTime  ? 'success' : 'danger')
-					 ->sortable(),
-		Tables\Columns\IconColumn::make('active')
-					 ->boolean()
-					 ->sortable(),
-		Tables\Columns\TextColumn::make('roles.name')
-					 ->badge()
-					 ->color(fn (string $state): string => match ($state) {
-					     'author' => 'success',
-					     'director' => 'warning',
-					     'admin' => 'danger',
-					     'default' => 'info',
-					 })
-					 ->searchable(),
-	    ])
-	    ->filters([
-		Tables\Filters\TernaryFilter::make('email_verified_at')
-					    ->label('Verified')
-					    ->nullable()
-					    ->placeholder('All'),
-		Tables\Filters\SelectFilter::make('active')
-					   ->options([
-					       true => 'Active',
-					       false => 'Inactive',
-					   ]),
-		Tables\Filters\Filter::make('no_roles')
-				     ->label('No Roles')
-				     ->query(fn ($query) => $query->whereDoesntHave('roles')),
-		Tables\Filters\SelectFilter::make('roles')
-					   ->relationship('roles','name')
-					   ->label('Role')
-	    ])
-	    ->actions([
-		Tables\Actions\EditAction::make(),
-	    ])
-	    ->bulkActions([
-		Tables\Actions\BulkActionGroup::make([
-		    // Placeholder
-		]),
-	    ])
-	    ->defaultSort('first_name');
+                    ->label('Email Verified')
+                    ->default('heroicon-o-x-circle')
+                    ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                    ->color(fn ($state) => $state instanceof \DateTime ? 'success' : 'danger')
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('active')
+                    ->boolean()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('roles.name')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'author' => 'success',
+                        'director' => 'warning',
+                        'admin' => 'danger',
+                        'default' => 'info',
+                    })
+                    ->searchable(),
+            ])
+            ->filters([
+                Tables\Filters\TernaryFilter::make('email_verified_at')
+                    ->label('Verified')
+                    ->nullable()
+                    ->placeholder('All'),
+                Tables\Filters\SelectFilter::make('active')
+                    ->options([
+                        true => 'Active',
+                        false => 'Inactive',
+                    ]),
+                Tables\Filters\Filter::make('no_roles')
+                    ->label('No Roles')
+                    ->query(fn ($query) => $query->whereDoesntHave('roles')),
+                Tables\Filters\SelectFilter::make('roles')
+                    ->relationship('roles', 'name')
+                    ->label('Role'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    // Placeholder
+                ]),
+            ])
+            ->defaultSort('first_name');
     }
 
     public static function getRelations(): array
     {
-	return [
-	    //
-	];
+        return [
+            //
+        ];
     }
 
     public static function getPages(): array
     {
-	return [
-	    'index' => Pages\ListUsers::route('/'),
-	    'create' => Pages\CreateUser::route('/create'),
-	    'edit' => Pages\EditUser::route('/{record}/edit'),
-	];
+        return [
+            'index' => Pages\ListUsers::route('/'),
+            'create' => Pages\CreateUser::route('/create'),
+            'edit' => Pages\EditUser::route('/{record}/edit'),
+        ];
     }
 }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -30,9 +30,6 @@ class EditUser extends EditRecord
      */
     protected function beforeSave(): void
     {
-        // $this->record->forceFill([
-        //     'active' => $this->data['active'],
-        // ])->save();
         $this->record->active = $this->data['active'];
         $this->record->save();
     }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -4,7 +4,6 @@ namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
 use Filament\Actions;
-use Filament\Forms;
 use Filament\Resources\Pages\EditRecord;
 
 class EditUser extends EditRecord
@@ -19,24 +18,23 @@ class EditUser extends EditRecord
     }
 
     /**
-    * Make email_verified_at visible so the table displays the correct True/False badges.
-    */
+     * Make email_verified_at visible so the table displays the correct True/False badges.
+     */
     protected function beforeFill(): void
     {
-	$this->record->makeVisible(['email_verified_at']);
-	}
-    
-    /**
-    * Force fill the Active attribute without having to make Active castable.
-    */
-    protected function beforeSave(): void
-    {
-	$this->record->forceFill([
-            'active' => $this->data['active'],
-	])->save();
+        $this->record->makeVisible(['email_verified_at']);
     }
 
-    
+    /**
+     * Force fill the Active attribute without having to make Active castable.
+     */
+    protected function beforeSave(): void
+    {
+        $this->record->forceFill([
+            'active' => $this->data['active'],
+        ])->save();
+    }
+
     /**
      * Get the URL to redirect to after performing an action in the EditUser page.
      *
@@ -52,12 +50,12 @@ class EditUser extends EditRecord
     }
 
     /**
-    * Set the email_verified_at attribute to the current DateTime.
-    */
+     * Set the email_verified_at attribute to the current DateTime.
+     */
     public function setVerifiedEmail(): void
     {
-	$this->record->forceFill([
-	    'email_verified_at' => now()
-	])->save();
-    }	 
+        $this->record->forceFill([
+            'email_verified_at' => now(),
+        ])->save();
+    }
 }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -17,6 +17,17 @@ class EditUser extends EditRecord
         ];
     }
 
+
+    /**
+    * Force fill the Active attribute without having to make Active castable.
+    */
+    protected function beforeSave(): void
+    {
+	$this->record->forceFill([
+            'active' => $this->data['active'],
+	])->save();
+    }
+
     /**
      * Get the URL to redirect to after performing an action in the EditUser page.
      *

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
 use Filament\Actions;
+use Filament\Forms;
 use Filament\Resources\Pages\EditRecord;
 
 class EditUser extends EditRecord
@@ -17,7 +18,14 @@ class EditUser extends EditRecord
         ];
     }
 
-
+    /**
+    * Make email_verified_at visible so the table displays the correct True/False badges.
+    */
+    protected function beforeFill(): void
+    {
+	$this->record->makeVisible(['email_verified_at']);
+	}
+    
     /**
     * Force fill the Active attribute without having to make Active castable.
     */
@@ -28,6 +36,7 @@ class EditUser extends EditRecord
 	])->save();
     }
 
+    
     /**
      * Get the URL to redirect to after performing an action in the EditUser page.
      *
@@ -41,4 +50,14 @@ class EditUser extends EditRecord
     {
         return $this->getResource()::getUrl('index');
     }
+
+    /**
+    * Set the email_verified_at attribute to the current DateTime.
+    */
+    public function setVerifiedEmail(): void
+    {
+	$this->record->forceFill([
+	    'email_verified_at' => now()
+	])->save();
+    }	 
 }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -30,9 +30,11 @@ class EditUser extends EditRecord
      */
     protected function beforeSave(): void
     {
-        $this->record->forceFill([
-            'active' => $this->data['active'],
-        ])->save();
+        // $this->record->forceFill([
+        //     'active' => $this->data['active'],
+        // ])->save();
+        $this->record->active = $this->data['active'];
+        $this->record->save();
     }
 
     /**
@@ -54,8 +56,6 @@ class EditUser extends EditRecord
      */
     public function setVerifiedEmail(): void
     {
-        $this->record->forceFill([
-            'email_verified_at' => now(),
-        ])->save();
+        $this->record->markEmailAsVerified();
     }
 }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -57,5 +57,6 @@ class EditUser extends EditRecord
     public function setVerifiedEmail(): void
     {
         $this->record->markEmailAsVerified();
+        $this->refreshFormData(['active']);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -185,14 +185,12 @@ class User extends Authenticatable implements FilamentUser, HasLocalePreference,
     public function markEmailAsVerified(): bool
     {
         if ($this->invitation) {
-            // $this->invitation->invitation_token = '';
             $this->invitation->registered_at = now();
             $this->invitation->save();
         }
 
         return $this->forceFill([
             'email_verified_at' => $this->freshTimestamp(),
-            // 'email_verification_token' => null,
             'active' => true,
         ])->save();
     }

--- a/config/mail.php
+++ b/config/mail.php
@@ -43,6 +43,8 @@ return [
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
             'local_domain' => env('MAIL_EHLO_DOMAIN'),
+            // todo: required for 7.2 support; remove when laravel fixes.
+            'scheme' => 'smtp',
         ],
 
         'ses' => [

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,7 +30,6 @@ class DatabaseSeeder extends Seeder
                 $this->call([
                     LocalTestDataSeeder::class,
                 ]);
-                $this->call(JournalsTableSeeder::class);
     }
         }
     }


### PR DESCRIPTION
This pull request includes updates to the Librarium `UserResource` and `EditUser` files to implement additional features to the Edit User panel. These changes close #813. 

### Frontend Changes
- Edit User table has been separated into two sections to group User Attributes and User Actions together. 
- A toggle switch has been added to the Edit Panel to toggle the **Active** status of a User.
- A button has been added to the Edit Panel to Verify a User's email.  
- Verify Email button will be hidden if a User's email is already verified.

### Backend Changes
- Logic has been added to allow for the force-filling of the **Active** attribute of the User model. This was required to bring functionality to the Toggle Switch.
- Logic has been added to allow for the force-filling of the **Email Verified At** attribute of the User model. This was required to bring functionality to the Action Button.
- The Verify Email button action updates the DateTime of the Email Verified At attribute instantaneously. Upon updating the button is hidden from the Edit Panel.  