### PR TITLE
feat(librarium): Reset password action

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -54,7 +54,10 @@ class UserResource extends Resource
                             Forms\Components\Actions\Action::make('verify_email')
                                 ->label('Activate & Verify')
                                 ->hidden(fn ($record) => $record && $record->email_verified_at)
-                                ->action('setVerifiedEmail'),
+							   ->action('setVerifiedEmail'),
+			    Forms\Components\Actions\Action::make('reset_password')
+							   ->label('Send Password Reset Email')
+			    ->action('sendPasswordReset'),
                         ]),
                     ]),
             ]);

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -95,31 +95,31 @@ class UserResource extends Resource
                     ->searchable(),
             ])
             ->filters([
-            Tables\Filters\TernaryFilter::make('email_verified_at')
+                Tables\Filters\TernaryFilter::make('email_verified_at')
                     ->label('Verified')
                     ->nullable()
                     ->placeholder('All'),
-            Tables\Filters\SelectFilter::make('active')
+                Tables\Filters\SelectFilter::make('active')
                     ->options([
                         true => 'Active',
                         false => 'Inactive',
                     ]),
-            Tables\Filters\Filter::make('no_roles')
+                Tables\Filters\Filter::make('no_roles')
                     ->label('No Roles')
                     ->query(fn ($query) => $query->whereDoesntHave('roles')),
-            Tables\Filters\SelectFilter::make('roles')
+                Tables\Filters\SelectFilter::make('roles')
                     ->relationship('roles', 'name')
                     ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
                     ->label('Role'),
-        ])
+            ])
             ->actions([
-            Tables\Actions\EditAction::make(),
-        ])
+                Tables\Actions\EditAction::make(),
+            ])
             ->bulkActions([
-            Tables\Actions\BulkActionGroup::make([
+                Tables\Actions\BulkActionGroup::make([
                     // Placeholder
-            ]),
-        ])
+                ]),
+            ])
             ->defaultSort('first_name');
     }
 

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -24,93 +24,93 @@ class UserResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('first_name')
-                    ->disabledOn('edit')
-                    ->filled()
-                    ->required(),
+					  ->disabledOn('edit')
+					  ->filled()
+					  ->required(),
                 Forms\Components\TextInput::make('last_name')
-                    ->disabledOn('edit')
-                    ->filled(),
+					  ->disabledOn('edit')
+					  ->filled(),
 
                 Forms\Components\Section::make('User Information')
-                    ->schema([
-                        Forms\Components\TextInput::make('email')
-                            ->filled()
-                            ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
-                        Forms\Components\CheckboxList::make('roles')
-                            ->relationship(titleAttribute: 'name')
-                            ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
-                            ->label('Roles'),
-                    ]),
+					->schema([
+					    Forms\Components\TextInput::make('email')
+								      ->filled()
+								      ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
+					    Forms\Components\CheckboxList::make('roles')
+									 ->relationship(titleAttribute: 'name')
+									 ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
+									 ->label('Roles'),
+					]),
 
                 Forms\Components\Section::make('Available Actions')
-                    ->description('Actions are instantaneous and may disappear once applied!')
-                    ->schema([
-                        Forms\Components\Toggle::make('active')
-                            ->label('Activate User')
-                            ->dehydrated(false)
-                            ->hidden(fn ($record) => $record && ! $record->email_verified_at)
-                            ->onColor('success'),
-                        Forms\Components\Actions::make([
-                            Forms\Components\Actions\Action::make('verify_email')
-                                ->label('Activate & Verify')
-                                ->hidden(fn ($record) => $record && $record->email_verified_at)
-							   ->action('setVerifiedEmail'),
-			    Forms\Components\Actions\Action::make('reset_password')
-							   ->label('Send Password Reset Email')
-			    ->action('sendPasswordReset'),
-                        ]),
-                    ]),
-            ]);
+					->description('Actions are instantaneous and may disappear once applied!')
+					->schema([
+					    Forms\Components\Toggle::make('active')
+								   ->label('Activate User')
+								   ->dehydrated(false)
+								   ->hidden(fn ($record) => $record && ! $record->email_verified_at)
+								   ->onColor('success'),
+						 Forms\Components\Actions::make([
+						     Forms\Components\Actions\Action::make('reset_password')
+										    ->label('Send Password Reset Email')
+										    ->action('sendPasswordReset'),
+						     Forms\Components\Actions\Action::make('verify_email')
+										    ->label('Activate User & Verify Email')
+										    ->disabled(fn ($record) => isset($record->email_verified_at))
+										    ->action('setVerifiedEmail'),
+						 ]),
+	    ]),
+    ]);
     }
 
     public static function table(Table $table): Table
     {
-        return $table
+	return $table
             ->columns([
                 Tables\Columns\TextColumn::make('first_name')
-                    ->searchable()
-                    ->sortable(),
+					 ->searchable()
+					 ->sortable(),
                 Tables\Columns\TextColumn::make('last_name')
-                    ->searchable()
-                    ->sortable(),
+					 ->searchable()
+					 ->sortable(),
                 Tables\Columns\TextColumn::make('email')
-                    ->searchable(),
+					 ->searchable(),
                 Tables\Columns\IconColumn::make('email_verified_at')
-                    ->label('Email Verified')
-                    ->default('heroicon-o-x-circle')
-                    ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
-                    ->color(fn ($state) => $state instanceof \DateTime ? 'success' : 'danger')
-                    ->sortable(),
+					 ->label('Email Verified')
+					 ->default('heroicon-o-x-circle')
+					 ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+					 ->color(fn ($state) => $state instanceof \DateTime ? 'success' : 'danger')
+					 ->sortable(),
                 Tables\Columns\IconColumn::make('active')
-                    ->boolean()
-                    ->sortable(),
+					 ->boolean()
+					 ->sortable(),
                 Tables\Columns\TextColumn::make('roles.name')
-                    ->badge()
-                    ->formatStateUsing(fn (string $state) => UserRole::from($state)->label())
-                    ->color(fn (string $state): string => match (UserRole::from($state)) {
-                        UserRole::AUTHOR => 'success',
-                        UserRole::DIRECTOR, UserRole::EDITOR, UserRole::CHIEF_EDITOR => 'warning',
-                        UserRole::ADMIN => 'danger',
-                    })
-                    ->searchable(),
+					 ->badge()
+					 ->formatStateUsing(fn (string $state) => UserRole::from($state)->label())
+					 ->color(fn (string $state): string => match (UserRole::from($state)) {
+					     UserRole::AUTHOR => 'success',
+					     UserRole::DIRECTOR, UserRole::EDITOR, UserRole::CHIEF_EDITOR => 'warning',
+					     UserRole::ADMIN => 'danger',
+					 })
+					 ->searchable(),
             ])
             ->filters([
                 Tables\Filters\TernaryFilter::make('email_verified_at')
-                    ->label('Verified')
-                    ->nullable()
-                    ->placeholder('All'),
+					    ->label('Verified')
+					    ->nullable()
+					    ->placeholder('All'),
                 Tables\Filters\SelectFilter::make('active')
-                    ->options([
-                        true => 'Active',
-                        false => 'Inactive',
-                    ]),
+					   ->options([
+					       true => 'Active',
+					       false => 'Inactive',
+					   ]),
                 Tables\Filters\Filter::make('no_roles')
-                    ->label('No Roles')
-                    ->query(fn ($query) => $query->whereDoesntHave('roles')),
+				     ->label('No Roles')
+				     ->query(fn ($query) => $query->whereDoesntHave('roles')),
                 Tables\Filters\SelectFilter::make('roles')
-                    ->relationship('roles', 'name')
-                    ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
-                    ->label('Role'),
+					   ->relationship('roles', 'name')
+					   ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
+					   ->label('Role'),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
@@ -125,17 +125,17 @@ class UserResource extends Resource
 
     public static function getRelations(): array
     {
-        return [
-            //
-        ];
+	return [
+	    //
+	];
     }
 
     public static function getPages(): array
     {
-        return [
-            'index' => Pages\ListUsers::route('/'),
-            'create' => Pages\CreateUser::route('/create'),
-            'edit' => Pages\EditUser::route('/{record}/edit'),
-        ];
+	return [
+	    'index' => Pages\ListUsers::route('/'),
+	    'create' => Pages\CreateUser::route('/create'),
+	    'edit' => Pages\EditUser::route('/{record}/edit'),
+	];
     }
 }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -24,118 +24,118 @@ class UserResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('first_name')
-					  ->disabledOn('edit')
-					  ->filled()
-					  ->required(),
+                    ->disabledOn('edit')
+                    ->filled()
+                    ->required(),
                 Forms\Components\TextInput::make('last_name')
-					  ->disabledOn('edit')
-					  ->filled(),
+                    ->disabledOn('edit')
+                    ->filled(),
 
                 Forms\Components\Section::make('User Information')
-					->schema([
-					    Forms\Components\TextInput::make('email')
-								      ->filled()
-								      ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
-					    Forms\Components\CheckboxList::make('roles')
-									 ->relationship(titleAttribute: 'name')
-									 ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
-									 ->label('Roles'),
-					]),
+                    ->schema([
+                        Forms\Components\TextInput::make('email')
+                            ->filled()
+                            ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain]),
+                        Forms\Components\CheckboxList::make('roles')
+                            ->relationship(titleAttribute: 'name')
+                            ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
+                            ->label('Roles'),
+                    ]),
 
                 Forms\Components\Section::make('Available Actions')
-					->description('Actions are instantaneous and may disappear once applied!')
-					->schema([
-					    Forms\Components\Toggle::make('active')
-								   ->label('Activate User')
-								   ->dehydrated(false)
-								   ->hidden(fn ($record) => $record && ! $record->email_verified_at)
-								   ->onColor('success'),
-						 Forms\Components\Actions::make([
-						     Forms\Components\Actions\Action::make('reset_password')
-										    ->label('Send Password Reset Email')
-										    ->action('sendPasswordReset'),
-						     Forms\Components\Actions\Action::make('verify_email')
-										    ->label('Activate User & Verify Email')
-										    ->disabled(fn ($record) => isset($record->email_verified_at))
-										    ->action('setVerifiedEmail'),
-						 ]),
-	    ]),
-    ]);
+                    ->description('Actions are instantaneous and may disappear once applied!')
+                    ->schema([
+                        Forms\Components\Toggle::make('active')
+                            ->label('Activate User')
+                            ->dehydrated(false)
+                            ->hidden(fn ($record) => $record && ! $record->email_verified_at)
+                            ->onColor('success'),
+                        Forms\Components\Actions::make([
+                            Forms\Components\Actions\Action::make('reset_password')
+                                ->label('Send Password Reset Email')
+                                ->action('sendPasswordReset'),
+                            Forms\Components\Actions\Action::make('verify_email')
+                                ->label('Activate User & Verify Email')
+                                ->disabled(fn ($record) => isset($record->email_verified_at))
+                                ->action('setVerifiedEmail'),
+                        ]),
+                    ]),
+            ]);
     }
 
     public static function table(Table $table): Table
     {
-	return $table
+        return $table
             ->columns([
                 Tables\Columns\TextColumn::make('first_name')
-					 ->searchable()
-					 ->sortable(),
+                    ->searchable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('last_name')
-					 ->searchable()
-					 ->sortable(),
+                    ->searchable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('email')
-					 ->searchable(),
+                    ->searchable(),
                 Tables\Columns\IconColumn::make('email_verified_at')
-					 ->label('Email Verified')
-					 ->default('heroicon-o-x-circle')
-					 ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
-					 ->color(fn ($state) => $state instanceof \DateTime ? 'success' : 'danger')
-					 ->sortable(),
+                    ->label('Email Verified')
+                    ->default('heroicon-o-x-circle')
+                    ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                    ->color(fn ($state) => $state instanceof \DateTime ? 'success' : 'danger')
+                    ->sortable(),
                 Tables\Columns\IconColumn::make('active')
-					 ->boolean()
-					 ->sortable(),
+                    ->boolean()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('roles.name')
-					 ->badge()
-					 ->formatStateUsing(fn (string $state) => UserRole::from($state)->label())
-					 ->color(fn (string $state): string => match (UserRole::from($state)) {
-					     UserRole::AUTHOR => 'success',
-					     UserRole::DIRECTOR, UserRole::EDITOR, UserRole::CHIEF_EDITOR => 'warning',
-					     UserRole::ADMIN => 'danger',
-					 })
-					 ->searchable(),
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => UserRole::from($state)->label())
+                    ->color(fn (string $state): string => match (UserRole::from($state)) {
+                        UserRole::AUTHOR => 'success',
+                        UserRole::DIRECTOR, UserRole::EDITOR, UserRole::CHIEF_EDITOR => 'warning',
+                        UserRole::ADMIN => 'danger',
+                    })
+                    ->searchable(),
             ])
             ->filters([
-                Tables\Filters\TernaryFilter::make('email_verified_at')
-					    ->label('Verified')
-					    ->nullable()
-					    ->placeholder('All'),
-                Tables\Filters\SelectFilter::make('active')
-					   ->options([
-					       true => 'Active',
-					       false => 'Inactive',
-					   ]),
-                Tables\Filters\Filter::make('no_roles')
-				     ->label('No Roles')
-				     ->query(fn ($query) => $query->whereDoesntHave('roles')),
-                Tables\Filters\SelectFilter::make('roles')
-					   ->relationship('roles', 'name')
-					   ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
-					   ->label('Role'),
-            ])
+            Tables\Filters\TernaryFilter::make('email_verified_at')
+                    ->label('Verified')
+                    ->nullable()
+                    ->placeholder('All'),
+            Tables\Filters\SelectFilter::make('active')
+                    ->options([
+                        true => 'Active',
+                        false => 'Inactive',
+                    ]),
+            Tables\Filters\Filter::make('no_roles')
+                    ->label('No Roles')
+                    ->query(fn ($query) => $query->whereDoesntHave('roles')),
+            Tables\Filters\SelectFilter::make('roles')
+                    ->relationship('roles', 'name')
+                    ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
+                    ->label('Role'),
+        ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-            ])
+            Tables\Actions\EditAction::make(),
+        ])
             ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
+            Tables\Actions\BulkActionGroup::make([
                     // Placeholder
-                ]),
-            ])
+            ]),
+        ])
             ->defaultSort('first_name');
     }
 
     public static function getRelations(): array
     {
-	return [
-	    //
-	];
+        return [
+            //
+        ];
     }
 
     public static function getPages(): array
     {
-	return [
-	    'index' => Pages\ListUsers::route('/'),
-	    'create' => Pages\CreateUser::route('/create'),
-	    'edit' => Pages\EditUser::route('/{record}/edit'),
-	];
+        return [
+            'index' => Pages\ListUsers::route('/'),
+            'create' => Pages\CreateUser::route('/create'),
+            'edit' => Pages\EditUser::route('/{record}/edit'),
+        ];
     }
 }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -63,21 +63,21 @@ class EditUser extends EditRecord
         }
         $this->record->markEmailAsVerified();
         $this->refreshFormData(['active']);
-	Notification::make()
-		    ->title('User\'s email is verified!')
-		    ->success()
-		    ->send();
+        Notification::make()
+            ->title('User\'s email is verified!')
+            ->success()
+            ->send();
     }
 
     /**
-    * Call the Reset Password Email process
-    */
+     * Call the Reset Password Email process
+     */
     public function sendPasswordReset(): void
     {
-	Password::sendResetLink(['email' => $this->data['email']]);
-	Notification::make()
-		    ->title('Reset password email sent!')
-		    ->success()
-		    ->send();
+        Password::sendResetLink(['email' => $this->data['email']]);
+        Notification::make()
+            ->title('Reset password email sent!')
+            ->success()
+            ->send();
     }
 }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
 use Filament\Actions;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Password;
 
@@ -62,10 +63,21 @@ class EditUser extends EditRecord
         }
         $this->record->markEmailAsVerified();
         $this->refreshFormData(['active']);
+	Notification::make()
+		    ->title('User\'s email is verified!')
+		    ->success()
+		    ->send();
     }
 
+    /**
+    * Call the Reset Password Email process
+    */
     public function sendPasswordReset(): void
     {
 	Password::sendResetLink(['email' => $this->data['email']]);
+	Notification::make()
+		    ->title('Reset password email sent!')
+		    ->success()
+		    ->send();
     }
 }

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\UserResource\Pages;
 use App\Filament\Resources\UserResource;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Facades\Password;
 
 class EditUser extends EditRecord
 {
@@ -61,5 +62,10 @@ class EditUser extends EditRecord
         }
         $this->record->markEmailAsVerified();
         $this->refreshFormData(['active']);
+    }
+
+    public function sendPasswordReset(): void
+    {
+	Password::sendResetLink(['email' => $this->data['email']]);
     }
 }

--- a/resources/src/auto-imports.d.ts
+++ b/resources/src/auto-imports.d.ts
@@ -334,9 +334,6 @@ declare global {
   // @ts-ignore
   export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
-  // @ts-ignore
-  export type { Locale } from './stores/LocaleStore'
-  import('./stores/LocaleStore')
 }
 
 // for vue template auto import


### PR DESCRIPTION
This pull request modifies the Librarium `UserResources` and `EditUser` files to implement an action to trigger the Reset Password flow on a user. Notifications when Verifying a User and Resetting their password have been added as a quality-of-life feature.

### Frontend Changes
- `Send Password Reset Email` button has been added to the Edit User page
- The `Activate User & Verify Email` button now shows all of the time in the Edit User page but is disabled when a User has a Verified Email
- A notification success message is now displayed when the `Send Password Reset Email` and `Activate User & Verify Email` actions are triggered

### Backend Changes 
- The `Activate User & Verify Email` action now implements the `disabled()` method. The action button is enabled when a User's `email_verified_at` attribute is null and disabled when not null
- The `Activate User & Verify Email` action no longer implements the `hidden()` method
- `Send Password Reset Email` and `Activate User & Verify Email` actions now implement Filament Notification objects with dedicated success messages