### PR TITLE
feat(librarium): Announcement management page

### DIFF
--- a/app/Filament/Resources/AnnouncementResource.php
+++ b/app/Filament/Resources/AnnouncementResource.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\AnnouncementResource\Pages;
+use App\Filament\Resources\AnnouncementResource\RelationManagers;
+use App\Models\Announcement;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Forms\Components\Actions;
+use Filament\Infolists\Components;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Carbon;
+
+class AnnouncementResource extends Resource
+{
+    protected static ?string $model = Announcement::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+		Forms\Components\Section::make('Announcement Content')
+					->columns(2)
+					->schema([
+					    Forms\Components\TextInput::make('title_en')
+								      ->label('Title English')
+								      ->required()
+								      ->maxLength(255),
+					    Forms\Components\TextInput::make('title_fr')
+								      ->label('Title French')
+								      ->required()
+								      ->maxLength(255),
+					    Forms\Components\Textarea::make('text_en')
+								     ->label('Announcement English')
+								     ->autosize()
+								     ->required()
+								     ->maxLength(500),
+					    Forms\Components\Textarea::make('text_fr')
+								     ->label('Announcement French')
+								     ->autosize()
+								     ->required()
+								     ->maxLength(500),
+					]),
+		Forms\Components\Section::make('Dates')
+					->description('All announcements will start at 00:00:00 UTC and end at 23:59:59 UTC of the dates selected!')
+					->schema([
+					    Forms\Components\DateTimePicker::make('start_at')
+									   ->label('Start Date')
+									   ->withoutTime()
+									   ->default(fn () => now()->startOfDay())
+									   ->required()
+									   ->afterOrEqual('yesterday')
+									   ->beforeOrEqual('end_at'),
+					    Forms\Components\DateTimePicker::make('end_at')
+									   ->label('End Date')
+									   ->withoutTime()
+									   ->default(fn () => now()->endOfDay())
+									   ->required()
+									   ->afterOrEqual('start_at'),
+					])
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+		Tables\Columns\TextColumn::make('title_en')
+					 ->label('Title English')
+					 ->wrap()
+					 ->sortable(),
+		Tables\Columns\TextColumn::make('title_fr')
+					 ->label('Title French')
+					 ->wrap()
+					 ->sortable(),
+		Tables\Columns\TextColumn::make('created_at')
+					 ->label('Created (UTC)')
+					 ->datetime('M d, Y H:i'),
+		Tables\Columns\TextColumn::make('start_at')
+					 ->label('Start (UTC)')
+					 ->datetime('M d, Y H:i')
+					 ->sortable(),
+		Tables\Columns\TextColumn::make('end_at')
+					 ->label('End (UTC)')
+					 ->datetime('M d, Y H:i')
+					 ->sortable(),
+		Tables\Columns\BadgeColumn::make('status')
+					  ->label('Status')
+					  ->getStateUsing(function ($record) {
+					      $now = Carbon::now();
+					      if ($record->start_at > $now) {
+						  return 'Upcoming';
+					      }
+					      if ($record->start_at <= $now && $record->end_at >= $now) {
+						  return 'Active';
+					      }
+					      if ($record->end_at < $now) {
+						  return 'Passed';
+					      }
+					  })
+					  ->colors([
+					      'warning' => 'Upcoming',
+					      'success' => 'Active',
+					      'info' => 'Passed',
+					  ])
+            ])
+	    ->defaultSort('start_at','desc')
+            ->filters([
+		//
+	    ])
+	    ->actions([
+		Tables\Actions\ViewAction::make(),
+		Tables\Actions\EditAction::make()
+					 ->mutateFormDataUsing(function (array $data): array {
+					     $data['end_at'] = $data['end_at'] . 'T23:59:59';
+
+					     return $data;
+					 }),
+					     Tables\Actions\DeleteAction::make(),
+					 ])
+	    ->bulkActions([
+		Tables\Actions\BulkActionGroup::make([
+		    Tables\Actions\DeleteBulkAction::make(),
+		]),
+	    ]);
+					 }
+
+		public static function infolist(Infolist $infolist): Infolist
+		{
+		    return $infolist
+	->schema([
+	    Components\Section::make('Info')
+			      ->schema([
+				  Components\Grid::make(2)
+						 ->schema([
+						     Components\Group::make([
+							 TextEntry::make('title_en')
+								  ->label('Title English'),
+							 TextEntry::make('created_at')
+								  ->label('Created (UTC)')
+								  ->datetime('M d, Y H:i'),
+							 TextEntry::make('start_at')
+								  ->label('Start (UTC)')
+								  ->datetime('M d, Y H:i'),
+						     ]),
+						     Components\Group::make([
+							 TextEntry::make('title_fr')
+								  ->label('Title French'),
+							 TextEntry::make('status')
+								  ->badge()
+								  ->getStateUsing(function ($record) {
+								      $now = Carbon::now();
+								      if ($record->start_at > $now) {
+									  return 'Upcoming';
+								      }
+								      if ($record->start_at <= $now && $record->end_at >= $now) {
+									  return 'Active';
+								      }
+								      if ($record->end_at < $now) {
+									  return 'Passed';
+								      }
+								  })
+								  ->colors([
+								      'secondary' => 'Upcoming',
+								      'success' => 'Active',
+								      'danger' => 'Passed',
+								  ]),
+							 TextEntry::make('end_at')
+								  ->label('End (UTC)')
+								  ->datetime('M d, Y H:i'),
+						     ])
+								     ->columns(1)
+						 ])
+			      ]),
+	    Components\Section::make('Message')
+			      ->schema([
+				  Components\TextEntry::make('text_en')
+						      ->label('English'),
+				  Components\TextEntry::make('text_fr')
+						      ->label('French'),
+			      ])
+	]);
+		}
+
+		public static function getRelations(): array
+		{
+		    return [
+			//
+		    ];
+		}
+
+		public static function getPages(): array
+		{
+		    return [
+			'index' => Pages\ListAnnouncements::route('/'),
+			'create' => Pages\CreateAnnouncement::route('/create'),
+			//	    'edit' => Pages\EditAnnouncement::route('/{record}/edit'),
+		    ];
+		}
+	    }

--- a/app/Filament/Resources/AnnouncementResource.php
+++ b/app/Filament/Resources/AnnouncementResource.php
@@ -3,19 +3,15 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\AnnouncementResource\Pages;
-use App\Filament\Resources\AnnouncementResource\RelationManagers;
 use App\Models\Announcement;
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Forms\Components\Actions;
 use Filament\Infolists\Components;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Carbon;
 
 class AnnouncementResource extends Resource
@@ -28,45 +24,45 @@ class AnnouncementResource extends Resource
     {
         return $form
             ->schema([
-		Forms\Components\Section::make('Announcement Content')
-					->columns(2)
-					->schema([
-					    Forms\Components\TextInput::make('title_en')
-								      ->label('Title English')
-								      ->required()
-								      ->maxLength(255),
-					    Forms\Components\TextInput::make('title_fr')
-								      ->label('Title French')
-								      ->required()
-								      ->maxLength(255),
-					    Forms\Components\Textarea::make('text_en')
-								     ->label('Announcement English')
-								     ->autosize()
-								     ->required()
-								     ->maxLength(500),
-					    Forms\Components\Textarea::make('text_fr')
-								     ->label('Announcement French')
-								     ->autosize()
-								     ->required()
-								     ->maxLength(500),
-					]),
-		Forms\Components\Section::make('Dates')
-					->description('All announcements will start at 00:00:00 UTC and end at 23:59:59 UTC of the dates selected!')
-					->schema([
-					    Forms\Components\DateTimePicker::make('start_at')
-									   ->label('Start Date')
-									   ->withoutTime()
-									   ->default(fn () => now()->startOfDay())
-									   ->required()
-									   ->afterOrEqual('yesterday')
-									   ->beforeOrEqual('end_at'),
-					    Forms\Components\DateTimePicker::make('end_at')
-									   ->label('End Date')
-									   ->withoutTime()
-									   ->default(fn () => now()->endOfDay())
-									   ->required()
-									   ->afterOrEqual('start_at'),
-					])
+                Forms\Components\Section::make('Announcement Content')
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\TextInput::make('title_en')
+                            ->label('Title English')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('title_fr')
+                            ->label('Title French')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\Textarea::make('text_en')
+                            ->label('Announcement English')
+                            ->autosize()
+                            ->required()
+                            ->maxLength(500),
+                        Forms\Components\Textarea::make('text_fr')
+                            ->label('Announcement French')
+                            ->autosize()
+                            ->required()
+                            ->maxLength(500),
+                    ]),
+                Forms\Components\Section::make('Dates')
+                    ->description('All announcements will start at 00:00:00 UTC and end at 23:59:59 UTC of the dates selected!')
+                    ->schema([
+                        Forms\Components\DateTimePicker::make('start_at')
+                            ->label('Start Date')
+                            ->Time(false)
+                            ->default(fn () => now()->startOfDay())
+                            ->required()
+                            ->afterOrEqual('yesterday')
+                            ->beforeOrEqual('end_at'),
+                        Forms\Components\DateTimePicker::make('end_at')
+                            ->label('End Date')
+                            ->Time(false)
+                            ->default(fn () => now()->endOfDay())
+                            ->required()
+                            ->afterOrEqual('start_at'),
+                    ]),
             ]);
     }
 
@@ -74,136 +70,136 @@ class AnnouncementResource extends Resource
     {
         return $table
             ->columns([
-		Tables\Columns\TextColumn::make('title_en')
-					 ->label('Title English')
-					 ->wrap()
-					 ->sortable(),
-		Tables\Columns\TextColumn::make('title_fr')
-					 ->label('Title French')
-					 ->wrap()
-					 ->sortable(),
-		Tables\Columns\TextColumn::make('created_at')
-					 ->label('Created (UTC)')
-					 ->datetime('M d, Y H:i'),
-		Tables\Columns\TextColumn::make('start_at')
-					 ->label('Start (UTC)')
-					 ->datetime('M d, Y H:i')
-					 ->sortable(),
-		Tables\Columns\TextColumn::make('end_at')
-					 ->label('End (UTC)')
-					 ->datetime('M d, Y H:i')
-					 ->sortable(),
-		Tables\Columns\BadgeColumn::make('status')
-					  ->label('Status')
-					  ->getStateUsing(function ($record) {
-					      $now = Carbon::now();
-					      if ($record->start_at > $now) {
-						  return 'Upcoming';
-					      }
-					      if ($record->start_at <= $now && $record->end_at >= $now) {
-						  return 'Active';
-					      }
-					      if ($record->end_at < $now) {
-						  return 'Passed';
-					      }
-					  })
-					  ->colors([
-					      'warning' => 'Upcoming',
-					      'success' => 'Active',
-					      'info' => 'Passed',
-					  ])
+                Tables\Columns\TextColumn::make('title_en')
+                    ->label('Title English')
+                    ->wrap()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('title_fr')
+                    ->label('Title French')
+                    ->wrap()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Created (UTC)')
+                    ->datetime('M d, Y H:i'),
+                Tables\Columns\TextColumn::make('start_at')
+                    ->label('Start (UTC)')
+                    ->datetime('M d, Y H:i')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('end_at')
+                    ->label('End (UTC)')
+                    ->datetime('M d, Y H:i')
+                    ->sortable(),
+                Tables\Columns\BadgeColumn::make('status')
+                    ->label('Status')
+                    ->getStateUsing(function ($record) {
+                        $now = Carbon::now();
+                        if ($record->start_at > $now) {
+                            return 'Upcoming';
+                        }
+                        if ($record->start_at <= $now && $record->end_at >= $now) {
+                            return 'Active';
+                        }
+                        if ($record->end_at < $now) {
+                            return 'Passed';
+                        }
+                    })
+                    ->colors([
+                        'warning' => 'Upcoming',
+                        'success' => 'Active',
+                        'info' => 'Passed',
+                    ]),
             ])
-	    ->defaultSort('start_at','desc')
+            ->defaultSort('start_at', 'desc')
             ->filters([
-		//
-	    ])
-	    ->actions([
-		Tables\Actions\ViewAction::make(),
-		Tables\Actions\EditAction::make()
-					 ->mutateFormDataUsing(function (array $data): array {
-					     $data['end_at'] = $data['end_at'] . 'T23:59:59';
+                //
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        $data['end_at'] = $data['end_at'].'T23:59:59';
 
-					     return $data;
-					 }),
-					     Tables\Actions\DeleteAction::make(),
-					 ])
-	    ->bulkActions([
-		Tables\Actions\BulkActionGroup::make([
-		    Tables\Actions\DeleteBulkAction::make(),
-		]),
-	    ]);
-					 }
+                        return $data;
+                    }),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
 
-		public static function infolist(Infolist $infolist): Infolist
-		{
-		    return $infolist
-	->schema([
-	    Components\Section::make('Info')
-			      ->schema([
-				  Components\Grid::make(2)
-						 ->schema([
-						     Components\Group::make([
-							 TextEntry::make('title_en')
-								  ->label('Title English'),
-							 TextEntry::make('created_at')
-								  ->label('Created (UTC)')
-								  ->datetime('M d, Y H:i'),
-							 TextEntry::make('start_at')
-								  ->label('Start (UTC)')
-								  ->datetime('M d, Y H:i'),
-						     ]),
-						     Components\Group::make([
-							 TextEntry::make('title_fr')
-								  ->label('Title French'),
-							 TextEntry::make('status')
-								  ->badge()
-								  ->getStateUsing(function ($record) {
-								      $now = Carbon::now();
-								      if ($record->start_at > $now) {
-									  return 'Upcoming';
-								      }
-								      if ($record->start_at <= $now && $record->end_at >= $now) {
-									  return 'Active';
-								      }
-								      if ($record->end_at < $now) {
-									  return 'Passed';
-								      }
-								  })
-								  ->colors([
-								      'secondary' => 'Upcoming',
-								      'success' => 'Active',
-								      'danger' => 'Passed',
-								  ]),
-							 TextEntry::make('end_at')
-								  ->label('End (UTC)')
-								  ->datetime('M d, Y H:i'),
-						     ])
-								     ->columns(1)
-						 ])
-			      ]),
-	    Components\Section::make('Message')
-			      ->schema([
-				  Components\TextEntry::make('text_en')
-						      ->label('English'),
-				  Components\TextEntry::make('text_fr')
-						      ->label('French'),
-			      ])
-	]);
-		}
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Components\Section::make('Info')
+                    ->schema([
+                        Components\Grid::make(2)
+                            ->schema([
+                                Components\Group::make([
+                                    TextEntry::make('title_en')
+                                        ->label('Title English'),
+                                    TextEntry::make('created_at')
+                                        ->label('Created (UTC)')
+                                        ->datetime('M d, Y H:i'),
+                                    TextEntry::make('start_at')
+                                        ->label('Start (UTC)')
+                                        ->datetime('M d, Y H:i'),
+                                ]),
+                                Components\Group::make([
+                                    TextEntry::make('title_fr')
+                                        ->label('Title French'),
+                                    TextEntry::make('status')
+                                        ->badge()
+                                        ->getStateUsing(function ($record) {
+                                            $now = Carbon::now();
+                                            if ($record->start_at > $now) {
+                                                return 'Upcoming';
+                                            }
+                                            if ($record->start_at <= $now && $record->end_at >= $now) {
+                                                return 'Active';
+                                            }
+                                            if ($record->end_at < $now) {
+                                                return 'Passed';
+                                            }
+                                        })
+                                        ->colors([
+                                            'secondary' => 'Upcoming',
+                                            'success' => 'Active',
+                                            'danger' => 'Passed',
+                                        ]),
+                                    TextEntry::make('end_at')
+                                        ->label('End (UTC)')
+                                        ->datetime('M d, Y H:i'),
+                                ])
+                                    ->columns(1),
+                            ]),
+                    ]),
+                Components\Section::make('Message')
+                    ->schema([
+                        Components\TextEntry::make('text_en')
+                            ->label('English'),
+                        Components\TextEntry::make('text_fr')
+                            ->label('French'),
+                    ]),
+            ]);
+    }
 
-		public static function getRelations(): array
-		{
-		    return [
-			//
-		    ];
-		}
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
 
-		public static function getPages(): array
-		{
-		    return [
-			'index' => Pages\ListAnnouncements::route('/'),
-			'create' => Pages\CreateAnnouncement::route('/create'),
-			//	    'edit' => Pages\EditAnnouncement::route('/{record}/edit'),
-		    ];
-		}
-	    }
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListAnnouncements::route('/'),
+            'create' => Pages\CreateAnnouncement::route('/create'),
+            //	    'edit' => Pages\EditAnnouncement::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/AnnouncementResource/Pages/CreateAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/CreateAnnouncement.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\AnnouncementResource\Pages;
+
+use App\Filament\Resources\AnnouncementResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAnnouncement extends CreateRecord
+{
+    protected static string $resource = AnnouncementResource::class;
+
+    protected static bool $canCreateAnother = false;
+    
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+	$data['end_at'] = $data['end_at'] . 'T23:59:59';
+
+	return $data;
+    }
+}

--- a/app/Filament/Resources/AnnouncementResource/Pages/CreateAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/CreateAnnouncement.php
@@ -10,11 +10,4 @@ class CreateAnnouncement extends CreateRecord
     protected static string $resource = AnnouncementResource::class;
 
     protected static bool $canCreateAnother = false;
-
-    protected function mutateFormDataBeforeCreate(array $data): array
-    {
-        $data['end_at'] = $data['end_at'].'T23:59:59';
-
-        return $data;
-    }
 }

--- a/app/Filament/Resources/AnnouncementResource/Pages/CreateAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/CreateAnnouncement.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Resources\AnnouncementResource\Pages;
 
 use App\Filament\Resources\AnnouncementResource;
-use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateAnnouncement extends CreateRecord
@@ -11,11 +10,11 @@ class CreateAnnouncement extends CreateRecord
     protected static string $resource = AnnouncementResource::class;
 
     protected static bool $canCreateAnother = false;
-    
+
     protected function mutateFormDataBeforeCreate(array $data): array
     {
-	$data['end_at'] = $data['end_at'] . 'T23:59:59';
+        $data['end_at'] = $data['end_at'].'T23:59:59';
 
-	return $data;
+        return $data;
     }
 }

--- a/app/Filament/Resources/AnnouncementResource/Pages/EditAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/EditAnnouncement.php
@@ -10,10 +10,10 @@ class EditAnnouncement extends EditRecord
 {
     protected static string $resource = AnnouncementResource::class;
 
-    protected function getHeaderActions(): array
-    {
-        return [
-            Actions\ViewAction::make(),
-        ];
-    }
+    // protected function getHeaderActions(): array
+    // {
+    //     return [
+    //         Actions\ViewAction::make(),
+    //     ];
+    // }
 }

--- a/app/Filament/Resources/AnnouncementResource/Pages/EditAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/EditAnnouncement.php
@@ -2,7 +2,6 @@
 
 namespace App\Filament\Resources\AnnouncementResource\Pages;
 
-use App\Models\Announcement;
 use App\Filament\Resources\AnnouncementResource;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;

--- a/app/Filament/Resources/AnnouncementResource/Pages/EditAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/EditAnnouncement.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Resources\AnnouncementResource\Pages;
+
+use App\Models\Announcement;
+use App\Filament\Resources\AnnouncementResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAnnouncement extends EditRecord
+{
+    protected static string $resource = AnnouncementResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AnnouncementResource/Pages/ListAnnouncements.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/ListAnnouncements.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AnnouncementResource\Pages;
+
+use App\Filament\Resources\AnnouncementResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAnnouncements extends ListRecords
+{
+    protected static string $resource = AnnouncementResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AnnouncementResource/Pages/ListAnnouncements.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/ListAnnouncements.php
@@ -13,7 +13,8 @@ class ListAnnouncements extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->icon('heroicon-o-plus-circle'),
         ];
     }
 }

--- a/app/Filament/Resources/AnnouncementResource/Pages/ViewAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/ViewAnnouncement.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AnnouncementResource\Pages;
+
+use App\Filament\Resources\AnnouncementResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewAnnouncement extends ViewRecord
+{
+    protected static string $resource = AnnouncementResource::class;
+    
+    protected function getHeaderActions(): array
+    {
+        return [
+	    Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AnnouncementResource/Pages/ViewAnnouncement.php
+++ b/app/Filament/Resources/AnnouncementResource/Pages/ViewAnnouncement.php
@@ -9,11 +9,11 @@ use Filament\Resources\Pages\ViewRecord;
 class ViewAnnouncement extends ViewRecord
 {
     protected static string $resource = AnnouncementResource::class;
-    
+
     protected function getHeaderActions(): array
     {
         return [
-	    Actions\EditAction::make(),
+            Actions\EditAction::make(),
         ];
     }
 }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -17,7 +17,7 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-users';
 
     public static function form(Form $form): Form
     {

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -39,15 +39,6 @@ class Announcement extends Model
     ];
 
     /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array<int, string>
-     */
-    /* protected $hidden = [
-       'created_at',
-     * ]; */
-
-    /**
      * Return active announcements
      */
     public function scopeActive(Builder $query)

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -30,12 +30,12 @@ class Announcement extends Model
      * @var array<int, string>
      */
     protected $fillable = [
-	'title_en',
-	'title_fr',
-	'text_en',
-	'text_fr',
-	'start_at',
-	'end_at',
+        'title_en',
+        'title_fr',
+        'text_en',
+        'text_fr',
+        'start_at',
+        'end_at',
     ];
 
     /**
@@ -44,6 +44,6 @@ class Announcement extends Model
     public function scopeActive(Builder $query)
     {
         return $query->where('start_at', '<=', now())
-		     ->where('end_at', '>=', now());
+            ->where('end_at', '>=', now());
     }
 }

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -25,11 +25,34 @@ class Announcement extends Model
     }
 
     /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+	'title_en',
+	'title_fr',
+	'text_en',
+	'text_fr',
+	'start_at',
+	'end_at',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    /* protected $hidden = [
+       'created_at',
+     * ]; */
+
+    /**
      * Return active announcements
      */
     public function scopeActive(Builder $query)
     {
         return $query->where('start_at', '<=', now())
-            ->where('end_at', '>=', now());
+		     ->where('end_at', '>=', now());
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -5862,16 +5862,16 @@
         },
         {
             "name": "openspout/openspout",
-            "version": "v4.28.3",
+            "version": "v4.28.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openspout/openspout.git",
-                "reference": "12b5eddcc230a97a9a67a722ad75c247e1a16750"
+                "reference": "68d58235c7c1164b3d231b798975b9b0b2b79b15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openspout/openspout/zipball/12b5eddcc230a97a9a67a722ad75c247e1a16750",
-                "reference": "12b5eddcc230a97a9a67a722ad75c247e1a16750",
+                "url": "https://api.github.com/repos/openspout/openspout/zipball/68d58235c7c1164b3d231b798975b9b0b2b79b15",
+                "reference": "68d58235c7c1164b3d231b798975b9b0b2b79b15",
                 "shasum": ""
             },
             "require": {
@@ -5885,13 +5885,13 @@
             },
             "require-dev": {
                 "ext-zlib": "*",
-                "friendsofphp/php-cs-fixer": "^3.65.0",
-                "infection/infection": "^0.29.8",
+                "friendsofphp/php-cs-fixer": "^3.66.1",
+                "infection/infection": "^0.29.10",
                 "phpbench/phpbench": "^1.3.1",
-                "phpstan/phpstan": "^2.0.3",
-                "phpstan/phpstan-phpunit": "^2.0.1",
+                "phpstan/phpstan": "^2.1.1",
+                "phpstan/phpstan-phpunit": "^2.0.3",
                 "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "^11.5.0"
+                "phpunit/phpunit": "^11.5.2"
             },
             "suggest": {
                 "ext-iconv": "To handle non UTF-8 CSV files (if \"php-mbstring\" is not already installed or is too limited)",
@@ -5939,7 +5939,7 @@
             ],
             "support": {
                 "issues": "https://github.com/openspout/openspout/issues",
-                "source": "https://github.com/openspout/openspout/tree/v4.28.3"
+                "source": "https://github.com/openspout/openspout/tree/v4.28.4"
             },
             "funding": [
                 {
@@ -5951,7 +5951,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-17T11:28:11+00:00"
+            "time": "2025-01-07T11:48:34+00:00"
         },
         {
             "name": "php-http/discovery",

--- a/resources/src/auto-imports.d.ts
+++ b/resources/src/auto-imports.d.ts
@@ -335,6 +335,9 @@ declare global {
   // @ts-ignore
   export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
+  // @ts-ignore
+  export type { Locale } from './stores/LocaleStore'
+  import('./stores/LocaleStore')
 }
 
 // for vue template auto import
@@ -407,6 +410,7 @@ declare module 'vue' {
     readonly onBeforeUpdate: UnwrapRef<typeof import('vue')['onBeforeUpdate']>
     readonly onClickOutside: UnwrapRef<typeof import('@vueuse/core')['onClickOutside']>
     readonly onDeactivated: UnwrapRef<typeof import('vue')['onDeactivated']>
+    readonly onElementRemoval: UnwrapRef<typeof import('@vueuse/core')['onElementRemoval']>
     readonly onErrorCaptured: UnwrapRef<typeof import('vue')['onErrorCaptured']>
     readonly onKeyStroke: UnwrapRef<typeof import('@vueuse/core')['onKeyStroke']>
     readonly onLongPress: UnwrapRef<typeof import('@vueuse/core')['onLongPress']>
@@ -583,6 +587,7 @@ declare module 'vue' {
     readonly usePreferredDark: UnwrapRef<typeof import('@vueuse/core')['usePreferredDark']>
     readonly usePreferredLanguages: UnwrapRef<typeof import('@vueuse/core')['usePreferredLanguages']>
     readonly usePreferredReducedMotion: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedMotion']>
+    readonly usePreferredReducedTransparency: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedTransparency']>
     readonly usePrevious: UnwrapRef<typeof import('@vueuse/core')['usePrevious']>
     readonly usePublicationStore: UnwrapRef<typeof import('./stores/PublicationStore')['usePublicationStore']>
     readonly useRafFn: UnwrapRef<typeof import('@vueuse/core')['useRafFn']>
@@ -591,6 +596,7 @@ declare module 'vue' {
     readonly useResizeObserver: UnwrapRef<typeof import('@vueuse/core')['useResizeObserver']>
     readonly useRoute: UnwrapRef<typeof import('vue-router')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router')['useRouter']>
+    readonly useSSRWidth: UnwrapRef<typeof import('@vueuse/core')['useSSRWidth']>
     readonly useScreenOrientation: UnwrapRef<typeof import('@vueuse/core')['useScreenOrientation']>
     readonly useScreenSafeArea: UnwrapRef<typeof import('@vueuse/core')['useScreenSafeArea']>
     readonly useScriptTag: UnwrapRef<typeof import('@vueuse/core')['useScriptTag']>

--- a/resources/src/auto-imports.d.ts
+++ b/resources/src/auto-imports.d.ts
@@ -335,9 +335,6 @@ declare global {
   // @ts-ignore
   export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
-  // @ts-ignore
-  export type { Locale } from './stores/LocaleStore'
-  import('./stores/LocaleStore')
 }
 
 // for vue template auto import
@@ -410,7 +407,6 @@ declare module 'vue' {
     readonly onBeforeUpdate: UnwrapRef<typeof import('vue')['onBeforeUpdate']>
     readonly onClickOutside: UnwrapRef<typeof import('@vueuse/core')['onClickOutside']>
     readonly onDeactivated: UnwrapRef<typeof import('vue')['onDeactivated']>
-    readonly onElementRemoval: UnwrapRef<typeof import('@vueuse/core')['onElementRemoval']>
     readonly onErrorCaptured: UnwrapRef<typeof import('vue')['onErrorCaptured']>
     readonly onKeyStroke: UnwrapRef<typeof import('@vueuse/core')['onKeyStroke']>
     readonly onLongPress: UnwrapRef<typeof import('@vueuse/core')['onLongPress']>
@@ -587,7 +583,6 @@ declare module 'vue' {
     readonly usePreferredDark: UnwrapRef<typeof import('@vueuse/core')['usePreferredDark']>
     readonly usePreferredLanguages: UnwrapRef<typeof import('@vueuse/core')['usePreferredLanguages']>
     readonly usePreferredReducedMotion: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedMotion']>
-    readonly usePreferredReducedTransparency: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedTransparency']>
     readonly usePrevious: UnwrapRef<typeof import('@vueuse/core')['usePrevious']>
     readonly usePublicationStore: UnwrapRef<typeof import('./stores/PublicationStore')['usePublicationStore']>
     readonly useRafFn: UnwrapRef<typeof import('@vueuse/core')['useRafFn']>
@@ -596,7 +591,6 @@ declare module 'vue' {
     readonly useResizeObserver: UnwrapRef<typeof import('@vueuse/core')['useResizeObserver']>
     readonly useRoute: UnwrapRef<typeof import('vue-router')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router')['useRouter']>
-    readonly useSSRWidth: UnwrapRef<typeof import('@vueuse/core')['useSSRWidth']>
     readonly useScreenOrientation: UnwrapRef<typeof import('@vueuse/core')['useScreenOrientation']>
     readonly useScreenSafeArea: UnwrapRef<typeof import('@vueuse/core')['useScreenSafeArea']>
     readonly useScriptTag: UnwrapRef<typeof import('@vueuse/core')['useScriptTag']>


### PR DESCRIPTION
This pull request adds `AnnouncementResources`, and associated Announcement page modification files to the Librarium. These additions allow for announcements to be created, edited, and deleted as per #893 . 

### Frontend Changes
- *Announcement* tab now present in Librarium dashboard
- Announcement index page displays tables containing Past, Current, and Upcoming announcements with creation, edit, and deletion buttons
- Announcement index page allows for viewing or editing of full details of an announcements in a popup window
- Announcement creation page contains form with required attributes for the creation of an announcement

### Backend Changes
- `AnnouncementResources.php` implements creation form with validation and viewable table
- The Announcement model now has title, text, and duration date attributes added to the `$fillable` array for mass assignment by Librarium
- `CreateAnnouncement.php` adds a `T23:59:59` time-element to `end_at` to force all announcements to end at end-of-day UTC
- The `EditAction` method adds a `T23:59:59` time-element to `end_at` if configured to force announcement to end at end-of-day UTC  