### PR TITLE
update(journal): increased journal list size

### DIFF
--- a/resources/src/auto-imports.d.ts
+++ b/resources/src/auto-imports.d.ts
@@ -335,9 +335,6 @@ declare global {
   // @ts-ignore
   export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
-  // @ts-ignore
-  export type { Locale } from './stores/LocaleStore'
-  import('./stores/LocaleStore')
 }
 
 // for vue template auto import
@@ -410,7 +407,6 @@ declare module 'vue' {
     readonly onBeforeUpdate: UnwrapRef<typeof import('vue')['onBeforeUpdate']>
     readonly onClickOutside: UnwrapRef<typeof import('@vueuse/core')['onClickOutside']>
     readonly onDeactivated: UnwrapRef<typeof import('vue')['onDeactivated']>
-    readonly onElementRemoval: UnwrapRef<typeof import('@vueuse/core')['onElementRemoval']>
     readonly onErrorCaptured: UnwrapRef<typeof import('vue')['onErrorCaptured']>
     readonly onKeyStroke: UnwrapRef<typeof import('@vueuse/core')['onKeyStroke']>
     readonly onLongPress: UnwrapRef<typeof import('@vueuse/core')['onLongPress']>
@@ -587,7 +583,6 @@ declare module 'vue' {
     readonly usePreferredDark: UnwrapRef<typeof import('@vueuse/core')['usePreferredDark']>
     readonly usePreferredLanguages: UnwrapRef<typeof import('@vueuse/core')['usePreferredLanguages']>
     readonly usePreferredReducedMotion: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedMotion']>
-    readonly usePreferredReducedTransparency: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedTransparency']>
     readonly usePrevious: UnwrapRef<typeof import('@vueuse/core')['usePrevious']>
     readonly usePublicationStore: UnwrapRef<typeof import('./stores/PublicationStore')['usePublicationStore']>
     readonly useRafFn: UnwrapRef<typeof import('@vueuse/core')['useRafFn']>
@@ -596,7 +591,6 @@ declare module 'vue' {
     readonly useResizeObserver: UnwrapRef<typeof import('@vueuse/core')['useResizeObserver']>
     readonly useRoute: UnwrapRef<typeof import('vue-router')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router')['useRouter']>
-    readonly useSSRWidth: UnwrapRef<typeof import('@vueuse/core')['useSSRWidth']>
     readonly useScreenOrientation: UnwrapRef<typeof import('@vueuse/core')['useScreenOrientation']>
     readonly useScreenSafeArea: UnwrapRef<typeof import('@vueuse/core')['useScreenSafeArea']>
     readonly useScriptTag: UnwrapRef<typeof import('@vueuse/core')['useScriptTag']>

--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -626,7 +626,7 @@
   "policy": {
     "for-more-info": "For more information please refer to the {policy}.",
     "intellectual-property-policy-copyright-act": "Intellectual Property Policy/Copyright Act",
-    "intellectual-property-policy-copyright-act-link": "https://www.dfo-mpo.gc.ca/copyright-droits-eng.htm",
+    "intellectual-property-policy-copyright-act-link": "https://www.dfo-mpo.gc.ca/terms-avis/copyright-droits-eng.htm",
     "message": {
       "p1": "Reviews the manuscript for compliance with the {copyrightsAct}, the {privacyAct}, the Financial Administration Act (with respect to approvals of publication costs) and the {valueAndEthicsCode}.\n",
       "p2": "Identifies when a manuscript is of potential public interest for the sole purpose of informing RDS and DFO regional Communications. Examples of topics of potential public interest could include subjects related to current events, or of stakeholder interest. These can include interesting stories to show case DFO research or studies that are more controversial. The inclusion of potentially sensitive material will never prevent the publication of a manuscript in any way."

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -624,7 +624,7 @@
   "policy": {
     "for-more-info": "Pour plus d'informations, veuillez consulter la {policy}.",
     "intellectual-property-policy-copyright-act": "Politique de propriété intellectuelle/ la loi sur le droit d'auteur",
-    "intellectual-property-policy-copyright-act-link": "https://www.dfo-mpo.gc.ca/copyright-droits-fra.htm",
+    "intellectual-property-policy-copyright-act-link": "https://www.dfo-mpo.gc.ca/terms-avis/copyright-droits-fra.htm",
     "message": {
       "p1": "Réviser le manuscrit pour vérifier qu'il respecte le {copyrightsAct}, la {privacyAct}, la loi sur la gestion financière (en ce qui concerne les approbations des coûts de publication) et le {valueAndEthicsCode}.",
       "p2": " Il identifiera également les cas où un manuscrit présente un intérêt potentiel pour le public, dans le seul but d'informer les Communications et le RDS. Des exemples de sujets d'intérêt public potentiel, incluent des sujets liés à l'actualité ou à l'intérêt des parties prenantes. Il peut s'agir d'histoires intéressantes pour illustrer les projets de recherches menés au MPO ou des sujets d'études qui sont plus controversées. L'inclusion de matériel potentiellement sensible n'empêchera jamais la publication d'un manuscrit."

--- a/resources/src/models/Journal/components/JournalSelect.vue
+++ b/resources/src/models/Journal/components/JournalSelect.vue
@@ -64,7 +64,7 @@ async function filterJournals(val: string, update: (arg: () => Promise<void>) =>
         .filter('search', needle)
         .sort('title-length', 'asc')
         .sort('title', 'asc')
-        .paginate(1, 10)
+        .paginate(1, 12)
 
       if (props.dfoSeriesOnly) {
         query.filter('dfo_series', 'true')


### PR DESCRIPTION
### What
This PR updates the `JournalSelect.vue` component to enhance the journal filtering functionality and address a broken hyperlink in both EN and FR locales.

### Why
1. The journal/series select list previously displayed an incomplete set of DFO series when filtering by ISN `1488-`, which could negatively impact user experience when creating publication records for already published manuscripts.
2. The hyperlink to the Crown Copyright policy redirected to a 404 page, as DFO has updated the URL.

### Frontend Changes
- Increased the size of the journal/series select list to display **12 records** (up from 10).
- Updated the hyperlink to the Crown Copyright page to the correct URL: [DFO - Crown Copyright](https://www.dfo-mpo.gc.ca/terms-avis/copyright-droits-eng.htm).

### Backend Changes
- Modified the `filterJournals` Spatie Query to `.paginate(1,12)`, ensuring all and only DFO series are included when filtering by ISN `1488-`.