### PR TITLE
update(env): updated env variables to work out of box for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@ APP_NAME="EOS-OSP"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
-FRONTEND_URL=http://localhost
+APP_URL=http://localhost:8000
+FRONTEND_URL=http://localhost:8000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
@@ -41,7 +41,7 @@ MAIL_FROM_NAME="${APP_NAME}"
 MAIL_LOG_CHANNEL=stack
 
 # changing this will require rebuilding the frontend as well.
-AZURE_ENABLE_AUTH=true
+AZURE_ENABLE_AUTH=false
 AZURE_TENANT_ID=
 AZURE_REDIRECT_URI="${FRONTEND_URL}/oauth/azure/callback"
 AZURE_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The commit message should be structured as follows:
 ### Backend Tests
 
 ```sh
-php artisan test
+composer run test
 ```
 
 ### Frontend Tests
@@ -116,11 +116,11 @@ We use Cypress for the front-end E2E tests. It must run with the
 
 Before starting the test, start the dev server. For the frontend,
 you can either use `pnpnm dev` or `pnmp build`. In most cases, `dev`
-is better as changes to the code can instantently be tested again.
+is better as changes to the code can instantly be tested again.
 
 ```sh
 pnpm dev
-php artisan server --env=ci
+php artisan serve --env=ci
 ```
 
 Once the local server is up and running, you can launch Cypress


### PR DESCRIPTION
## What
This PR makes changes to the default values in `.env.example` to improve the streamline of getting a development instance up and running.

## Backend Changes
- `*_URL` variables include default port number
- `AZURE_ENABLE_AUTH` is set to `false` by default

## Frontend Changes
- `README.md` backend test script updated to `composer run test`