### PR TITLE
update(librarium): health monitors and password change

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -38,21 +38,21 @@ class UserResource extends Resource
                         Forms\Components\TextInput::make('email')
                             ->filled()
                             ->rules(['bail', 'required', 'string', 'email', new AuthorizedEmailDomain])
-                            ->disabled(fn() => config('osp.azure.enable_auth', false)),
+                            ->disabled(fn () => config('osp.azure.enable_auth', false)),
                         Forms\Components\CheckboxList::make('roles')
                             ->relationship(titleAttribute: 'name')
-                            ->getOptionLabelFromRecordUsing(fn(Role $record) => UserRole::from($record->name)->label())
+                            ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
                             ->label('Roles'),
                     ]),
                 Forms\Components\Section::make('Change Password')
-                ->schema([
-                    Forms\Components\TextInput::make('password')
+                    ->schema([
+                        Forms\Components\TextInput::make('password')
                             ->label('Change Password')
                             ->password()
                             ->rules([Password::min(config('auth.password_min_length'))->uncompromised()])
                             ->dehydrateStateUsing(fn (string $state): string => Hash::make($state))
                             ->dehydrated(fn (?string $state): bool => filled($state)),
-                ]),
+                    ]),
 
                 Forms\Components\Section::make('Available Actions')
                     ->description('Actions are instantaneous and may disappear once applied!')
@@ -60,19 +60,19 @@ class UserResource extends Resource
                         Forms\Components\Toggle::make('active')
                             ->label('Activate User')
                             ->dehydrated(false)
-                            ->hidden(fn($record) => $record && ! $record->email_verified_at)
+                            ->hidden(fn ($record) => $record && ! $record->email_verified_at)
                             ->onColor('success'),
                         Forms\Components\Actions::make([
                             Forms\Components\Actions\Action::make('reset_password')
                                 ->label('Send Password Reset Email')
-                                ->disabled(fn() => config('osp.azure.enable_auth', false))
+                                ->disabled(fn () => config('osp.azure.enable_auth', false))
                                 ->action('sendPasswordReset'),
                             Forms\Components\Actions\Action::make('verify_email')
                                 ->label('Activate User & Verify Email')
-                                ->disabled(fn($record) => isset($record->email_verified_at))
+                                ->disabled(fn ($record) => isset($record->email_verified_at))
                                 ->action('setVerifiedEmail'),
                         ]),
-                    ])
+                    ]),
             ]);
     }
 
@@ -91,16 +91,16 @@ class UserResource extends Resource
                 Tables\Columns\IconColumn::make('email_verified_at')
                     ->label('Email Verified')
                     ->default('heroicon-o-x-circle')
-                    ->icon(fn($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
-                    ->color(fn($state) => $state instanceof \DateTime ? 'success' : 'danger')
+                    ->icon(fn ($state) => $state instanceof \DateTime ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                    ->color(fn ($state) => $state instanceof \DateTime ? 'success' : 'danger')
                     ->sortable(),
                 Tables\Columns\IconColumn::make('active')
                     ->boolean()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('roles.name')
                     ->badge()
-                    ->formatStateUsing(fn(string $state) => UserRole::from($state)->label())
-                    ->color(fn(string $state): string => match (UserRole::from($state)) {
+                    ->formatStateUsing(fn (string $state) => UserRole::from($state)->label())
+                    ->color(fn (string $state): string => match (UserRole::from($state)) {
                         UserRole::AUTHOR => 'success',
                         UserRole::DIRECTOR, UserRole::EDITOR, UserRole::CHIEF_EDITOR => 'warning',
                         UserRole::ADMIN => 'danger',
@@ -119,10 +119,10 @@ class UserResource extends Resource
                     ]),
                 Tables\Filters\Filter::make('no_roles')
                     ->label('No Roles')
-                    ->query(fn($query) => $query->whereDoesntHave('roles')),
+                    ->query(fn ($query) => $query->whereDoesntHave('roles')),
                 Tables\Filters\SelectFilter::make('roles')
                     ->relationship('roles', 'name')
-                    ->getOptionLabelFromRecordUsing(fn(Role $record) => UserRole::from($record->name)->label())
+                    ->getOptionLabelFromRecordUsing(fn (Role $record) => UserRole::from($record->name)->label())
                     ->label('Role'),
             ])
             ->actions([

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -35,18 +35,16 @@ class EditUser extends EditRecord
         if (! $this->record instanceof \App\Models\User) {
             return;
         }
-        
+
         // log password change
         if ($this->record->password != $this->data['password'] and $this->data['password']) {
             $this->logPasswordChange();
-        };
+        }
         // update active status
-        if ($this->record->active != $this->data['active']) {
+        if ($this->record['active'] != $this->data['active']) {
             $this->saveActiveStatus();
-        };
-        
+        }
     }
-
 
     /**
      * Get the URL to redirect to after performing an action in the EditUser page.
@@ -76,20 +74,20 @@ class EditUser extends EditRecord
                 'ip' => request()->ip(),
             ])
             ->event('password.changed')
-            ->log("Password changed for {$this->record['email']} by " . request()->user()->email);
+            ->log("Password changed for {$this->record['email']} by ".request()->user()->email);
 
-            Notification::make()
+        Notification::make()
             ->title('Password Changed')
             ->success()
             ->send();
     }
 
     /**
-     * Save change in status to the database and log status change 
+     * Save change in status to the database and log status change
      */
     public function saveActiveStatus(): void
     {
-        $this->record->active = $this->data['active'];
+        $this->record['active'] = $this->data['active'];
         $this->record->save();
 
         // log active status change
@@ -102,7 +100,7 @@ class EditUser extends EditRecord
                 'ip' => request()->ip(),
             ])
             ->event('active.status.changed')
-            ->log("Active status changed for {$this->record['email']} by " . request()->user()->email . ": ". (! $this->record['active'] ? 'active' : 'inactive') . " -> " . ($this->record['active'] ? 'active' : 'inactive'));
+            ->log("Active status changed for {$this->record['email']} by ".request()->user()->email.': '.(! $this->record['active'] ? 'active' : 'inactive').' -> '.($this->record['active'] ? 'active' : 'inactive'));
     }
 
     /**

--- a/app/Filament/Widgets/StatusLinks.php
+++ b/app/Filament/Widgets/StatusLinks.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class StatusLinks extends BaseWidget
+{
+
+    protected function getStats(): array
+    {
+        return [
+            Stat::make('','System Health Panel')
+                ->url(url('/health'))
+                ->extraAttributes(['class' => 'text-center']),
+
+            Stat::make("", 'Horizon')
+                ->url(url('/horizon'))
+                ->extraAttributes(['class' => 'text-center']),
+
+                Stat::make('', 'Pulse')
+                ->url(url('/pulse'))
+                ->extraAttributes(['class' => 'text-center']),
+        ];
+    }
+}

--- a/app/Filament/Widgets/StatusLinks.php
+++ b/app/Filament/Widgets/StatusLinks.php
@@ -7,19 +7,18 @@ use Filament\Widgets\StatsOverviewWidget\Stat;
 
 class StatusLinks extends BaseWidget
 {
-
     protected function getStats(): array
     {
         return [
-            Stat::make('','System Health Panel')
+            Stat::make('', 'System Health Panel')
                 ->url(url('/health'))
                 ->extraAttributes(['class' => 'text-center']),
 
-            Stat::make("", 'Horizon')
+            Stat::make('', 'Horizon')
                 ->url(url('/horizon'))
                 ->extraAttributes(['class' => 'text-center']),
 
-                Stat::make('', 'Pulse')
+            Stat::make('', 'Pulse')
                 ->url(url('/pulse'))
                 ->extraAttributes(['class' => 'text-center']),
         ];

--- a/app/Providers/Filament/LibrariumPanelProvider.php
+++ b/app/Providers/Filament/LibrariumPanelProvider.php
@@ -39,7 +39,6 @@ class LibrariumPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([
                 Widgets\AccountWidget::class,
-                Widgets\FilamentInfoWidget::class,
             ])
             ->middleware([
                 EncryptCookies::class,


### PR DESCRIPTION
### What
This PR adds hyperlinks to the health pages to the Librarium landing page Dashboard and adds password changing functionality to the edit user form. 

### Frontend Changes
- Three cards appear on the Dashboard page with descriptive text of what health page they redirect to
- The Filament Documentation card has been removed
- The Edit User form now has a section to change a user's password and a success notification when a password is changed
- The Email element within the Edit User form is now disabled from editing when using the Azure authentication flow
- The Send Reset Email action button within the Edit User form is now disabled when using the Azure authentication flow

### Backend Changes
- A `Widgets` folder has been added to the Filament directory to house custom widgets
- `FilamentInfoWidget` has been removed from `LibrariumPanelProvider` 
- The `UserResource` file now has an change password flow that uses the same ruleset and Hash method as `PasswordChangeRequest`
- The change password element will remain dehydrated when the element is left empty/null
- The `EditUser` `beforeSave` method now has logic checks to call relevant methods when changes are made to the Edit User form.
- `logPasswordChange` method has been added to `EditUser` to handle updating the Activity Log and creating a success notification
- `saveActiveStatus` method has been added to handle saving changes to a user's active attribute and updating the Activity Log
- The Activity Log flow has had `performedOn` and `event` attributes added to logging

### Proposed Changes to Activity Logging style
- include `performedOn` and `event` attribute in logging events
- add additional attributes to `withProperties`, `{target_email: foo, actor_email: bar, ip: foobar}` 
- For `events`, adopt a minimalist description of event occuring. i.e. `password.changed`, `roles.changed`, `active.status.changed`, etc
- For `log`, adopt the message format `[Action] performed on [Target User] by [Actor]` or `[Action] performed on [Target User] by [Actor]: [Before Value] -> [After Value]`

### Issues
This closes #821 