### PR TITLE
Preprint View Feature

### DIFF
--- a/app/Enums/Permissions/UserPermission.php
+++ b/app/Enums/Permissions/UserPermission.php
@@ -16,6 +16,7 @@ enum UserPermission: string
     case VIEW_HORIZON = 'view_horizon';
     case VIEW_PULSE = 'view_pulse';
     case VIEW_ANY_USERS = 'view_any_users';
+    case VIEW_ANY_MANUSCRIPT_RECORD = 'view_any_manuscript_record';
     case ADMINISTER_USERS = 'administer_users';
     case PUBLISH_INTERNAL_REPORTS = 'publish_internal_reports';
     case UPDATE_PUBLICATIONS = 'update_publications';

--- a/app/Enums/Permissions/UserRole.php
+++ b/app/Enums/Permissions/UserRole.php
@@ -27,6 +27,7 @@ enum UserRole: string
             ],
             self::DIRECTOR => [
                 UserPermission::COMPLETE_INTERNTAL_MANAGEMENT_REVIEW,
+                UserPermission::VIEW_ANY_MANUSCRIPT_RECORD,
                 // Merge author permissions
                 ...self::AUTHOR->permissions(),
             ],
@@ -41,6 +42,7 @@ enum UserRole: string
             self::EDITOR => [
                 UserPermission::UPDATE_AUTHORS,
                 UserPermission::UPDATE_PUBLICATIONS,
+                UserPermission::VIEW_ANY_MANUSCRIPT_RECORD,
             ],
             self::CHIEF_EDITOR => [
                 UserPermission::PUBLISH_INTERNAL_REPORTS,

--- a/app/Http/Controllers/PreprintController.php
+++ b/app/Http/Controllers/PreprintController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Http\Resources\PreprintResource;
-use App\Models\ManuscriptRecord;
 use App\Queries\PreprintListQuery;
 use App\Traits\PaginationLimitTrait;
 use Illuminate\Http\Request;
@@ -12,6 +11,7 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 class PreprintController extends Controller
 {
     use PaginationLimitTrait;
+
     /**
      * Display a listing of the resource.
      */
@@ -22,5 +22,4 @@ class PreprintController extends Controller
 
         return PreprintResource::collection($preprintQuery->paginate($limit));
     }
-
 }

--- a/app/Http/Controllers/PreprintController.php
+++ b/app/Http/Controllers/PreprintController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\PreprintResource;
+use App\Models\ManuscriptRecord;
+use App\Queries\PreprintListQuery;
+use App\Traits\PaginationLimitTrait;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PreprintController extends Controller
+{
+    use PaginationLimitTrait;
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request): ResourceCollection
+    {
+        $limit = $this->getLimitFromRequest($request);
+        $preprintQuery = new PreprintListQuery;
+
+        return PreprintResource::collection($preprintQuery->paginate($limit));
+    }
+
+}

--- a/app/Http/Resources/PreprintResource.php
+++ b/app/Http/Resources/PreprintResource.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\ManuscriptAuthor;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\ManuscriptRecord
+ */
+class PreprintResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'data' => [
+                'manuscript_record_id' => $this->id,
+                'title' => $this->title,
+                'region_id' => $this->region_id,
+                'preprint_url' => $this->preprint_url,
+                'accepted_on' => $this->accepted_on,
+                // relationships
+                'authors' => ManuscriptAuthorResource::collection($this->whenLoaded('manuscriptAuthors')),
+                'user' => UserResource::make($this->whenLoaded('user'))
+            ],
+            'can' => [
+                'udpate' => false,
+                'delete' => false
+            ]
+        ];
+    }
+}

--- a/app/Http/Resources/PreprintResource.php
+++ b/app/Http/Resources/PreprintResource.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Resources;
 
-use App\Models\ManuscriptAuthor;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @mixin \App\Models\ManuscriptRecord
@@ -27,12 +27,13 @@ class PreprintResource extends JsonResource
                 'accepted_on' => $this->accepted_on,
                 // relationships
                 'authors' => ManuscriptAuthorResource::collection($this->whenLoaded('manuscriptAuthors')),
-                'user' => UserResource::make($this->whenLoaded('user'))
+                'user' => UserResource::make($this->whenLoaded('user')),
             ],
             'can' => [
+                'view' => Auth::user()->can('view', $this->resource),
                 'udpate' => false,
-                'delete' => false
-            ]
+                'delete' => false,
+            ],
         ];
     }
 }

--- a/app/Policies/ManuscriptRecordPolicy.php
+++ b/app/Policies/ManuscriptRecordPolicy.php
@@ -34,7 +34,7 @@ class ManuscriptRecordPolicy
     public function view(User $user, ManuscriptRecord $manuscriptRecord)
     {
 
-        if($user->can(UserPermission::VIEW_ANY_MANUSCRIPT_RECORD)){
+        if ($user->can(UserPermission::VIEW_ANY_MANUSCRIPT_RECORD)) {
             return $manuscriptRecord->status !== ManuscriptRecordStatus::DRAFT;
         }
 

--- a/app/Policies/ManuscriptRecordPolicy.php
+++ b/app/Policies/ManuscriptRecordPolicy.php
@@ -21,6 +21,8 @@ class ManuscriptRecordPolicy
      */
     public function viewAny(User $user)
     {
+        // this should stay false as the "draft" MRF should
+        // never be seen by "anyone".
         return false;
     }
 
@@ -31,6 +33,10 @@ class ManuscriptRecordPolicy
      */
     public function view(User $user, ManuscriptRecord $manuscriptRecord)
     {
+
+        if($user->can(UserPermission::VIEW_ANY_MANUSCRIPT_RECORD)){
+            return $manuscriptRecord->status !== ManuscriptRecordStatus::DRAFT;
+        }
 
         // owners can view their own manuscripts
         if ($user->id === $manuscriptRecord->user_id) {

--- a/app/Queries/PreprintListQuery.php
+++ b/app/Queries/PreprintListQuery.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Queries;
+
+use App\Enums\ManuscriptRecordStatus;
+use App\Enums\ManuscriptRecordType;
+use App\Models\ManuscriptRecord;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class PreprintListQuery extends QueryBuilder
+{
+    public function __construct()
+    {
+        parent::__construct(
+            ManuscriptRecord::query()
+                ->where('type', ManuscriptRecordType::PREPRINT)
+                ->where('status', ManuscriptRecordStatus::ACCEPTED)
+                ->with('manuscriptAuthors.author','manuscriptAuthors.organization')
+        );
+
+        $this
+            ->defaultSort('accepted_on')
+            ->allowedSorts([
+                'title'
+            ])
+            ->allowedFilters([
+                AllowedFilter::exact('id'),
+                AllowedFilter::exact('user_id'),
+                AllowedFilter::partial('title'),
+                AllowedFilter::exact('manuscriptAuthor.author_id')
+            ]);
+    }
+}

--- a/app/Queries/PreprintListQuery.php
+++ b/app/Queries/PreprintListQuery.php
@@ -20,8 +20,8 @@ class PreprintListQuery extends QueryBuilder
                     'manuscriptAuthors.author',
                     'manuscriptAuthors.organization',
                     'managementReviewSteps',
-                    'shareables'
-                    ])
+                    'shareables',
+                ])
 
         );
 

--- a/app/Queries/PreprintListQuery.php
+++ b/app/Queries/PreprintListQuery.php
@@ -28,7 +28,7 @@ class PreprintListQuery extends QueryBuilder
                 AllowedFilter::exact('id'),
                 AllowedFilter::exact('user_id'),
                 AllowedFilter::partial('title'),
-                AllowedFilter::exact('manuscriptAuthor.author_id')
+                AllowedFilter::exact('manuscriptAuthors.author_id')
             ]);
     }
 }

--- a/app/Queries/PreprintListQuery.php
+++ b/app/Queries/PreprintListQuery.php
@@ -16,7 +16,13 @@ class PreprintListQuery extends QueryBuilder
             ManuscriptRecord::query()
                 ->where('type', ManuscriptRecordType::PREPRINT)
                 ->where('status', ManuscriptRecordStatus::ACCEPTED)
-                ->with('manuscriptAuthors.author', 'manuscriptAuthors.organization')
+                ->with([
+                    'manuscriptAuthors.author',
+                    'manuscriptAuthors.organization',
+                    'managementReviewSteps',
+                    'shareables'
+                    ])
+
         );
 
         $this

--- a/app/Queries/PreprintListQuery.php
+++ b/app/Queries/PreprintListQuery.php
@@ -16,19 +16,19 @@ class PreprintListQuery extends QueryBuilder
             ManuscriptRecord::query()
                 ->where('type', ManuscriptRecordType::PREPRINT)
                 ->where('status', ManuscriptRecordStatus::ACCEPTED)
-                ->with('manuscriptAuthors.author','manuscriptAuthors.organization')
+                ->with('manuscriptAuthors.author', 'manuscriptAuthors.organization')
         );
 
         $this
             ->defaultSort('accepted_on')
             ->allowedSorts([
-                'title'
+                'title',
             ])
             ->allowedFilters([
                 AllowedFilter::exact('id'),
                 AllowedFilter::exact('user_id'),
                 AllowedFilter::partial('title'),
-                AllowedFilter::exact('manuscriptAuthors.author_id')
+                AllowedFilter::exact('manuscriptAuthors.author_id'),
             ]);
     }
 }

--- a/database/factories/ManuscriptRecordFactory.php
+++ b/database/factories/ManuscriptRecordFactory.php
@@ -124,7 +124,7 @@ class ManuscriptRecordFactory extends Factory
     public function publishedPreprint()
     {
         return $this->accepted()->state([
-            'title' => 'A preprint' . $this->faker->text(50),
+            'title' => 'A preprint: ' . $this->faker->text(50),
             'submitted_to_journal_on' => now(),
             'accepted_on' => now(),
             'type' => ManuscriptRecordType::PREPRINT,

--- a/database/factories/ManuscriptRecordFactory.php
+++ b/database/factories/ManuscriptRecordFactory.php
@@ -124,11 +124,11 @@ class ManuscriptRecordFactory extends Factory
     public function publishedPreprint()
     {
         return $this->accepted()->state([
-            'title' => 'A preprint: ' . $this->faker->text(50),
+            'title' => 'A preprint: '.$this->faker->text(50),
             'submitted_to_journal_on' => now(),
             'accepted_on' => now(),
             'type' => ManuscriptRecordType::PREPRINT,
-            'preprint_url' => $this->faker->url()
+            'preprint_url' => $this->faker->url(),
         ]);
     }
 }

--- a/database/factories/ManuscriptRecordFactory.php
+++ b/database/factories/ManuscriptRecordFactory.php
@@ -117,4 +117,18 @@ class ManuscriptRecordFactory extends Factory
             'accepted_on' => now(),
         ]);
     }
+
+    /**
+     * A published preprint - accepted with url.
+     */
+    public function publishedPreprint()
+    {
+        return $this->accepted()->state([
+            'title' => 'A preprint' . $this->faker->text(50),
+            'submitted_to_journal_on' => now(),
+            'accepted_on' => now(),
+            'type' => ManuscriptRecordType::PREPRINT,
+            'preprint_url' => $this->faker->url()
+        ]);
+    }
 }

--- a/database/seeders/LocalTestDataSeeder.php
+++ b/database/seeders/LocalTestDataSeeder.php
@@ -173,7 +173,6 @@ class LocalTestDataSeeder extends Seeder
             'text_fr' => 'Ceci est une annonce de test.',
         ]);
 
-
         // let's add a few preprints
         ManuscriptRecord::factory()->publishedPreprint()->count(5)->create();
 

--- a/database/seeders/LocalTestDataSeeder.php
+++ b/database/seeders/LocalTestDataSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Enums\PublicationStatus;
 use App\Models\ManagementReviewStep;
 use App\Models\ManuscriptAuthor;
+use App\Models\ManuscriptRecord;
 use App\Models\PublicationAuthor;
 use App\Models\Shareable;
 use Illuminate\Database\Seeder;
@@ -171,6 +172,10 @@ class LocalTestDataSeeder extends Seeder
             'text_en' => 'This is a test announcement.',
             'text_fr' => 'Ceci est une annonce de test.',
         ]);
+
+
+        // let's add a few preprints
+        ManuscriptRecord::factory()->publishedPreprint()->count(5)->create();
 
         activity()->enableLogging();
     }

--- a/resources/src/components/MainDrawer.vue
+++ b/resources/src/components/MainDrawer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { QDrawer, QItemLabel, QList, QSeparator } from 'quasar'
 import type { MenuItem } from './DrawerMenuItem.vue'
+import { QDrawer, QItemLabel, QList, QSeparator } from 'quasar'
 import DrawerMenuItem from './DrawerMenuItem.vue'
 
 const authStore = useAuthStore()
@@ -45,6 +45,13 @@ const exploreMenuItems = computed<MenuItem[]>(() => {
       icon: 'mdi-newspaper-variant-multiple-outline',
       label: t('common.publications'),
       to: '/publications',
+      visible: true,
+      tooltipVisible: authStore.isDrawerMini,
+    },
+    {
+      icon: 'mdi-cloud-print-outline',
+      label: t('common.preprints'),
+      to: '/preprints',
       visible: true,
       tooltipVisible: authStore.isDrawerMini,
     },

--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -295,7 +295,8 @@
     "preprint-url-hint": "The DOI or a URL linking directly to the preprint",
     "submitted-to-preprint-on": "Date submitted to preprint server",
     "preprint": "Preprint",
-    "view-preprint": "External Link"
+    "view-preprint": "External Link",
+    "preprints": "Preprints"
   },
   "create-author-dialog": {
     "title": "Create a new author"

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -291,7 +291,8 @@
     "preprint-url-hint": "Le doi ou une URL liant directement à la prépublication",
     "preprint-url": "DOI ou URL de la prépublication",
     "preprint": "Prépublication",
-    "view-preprint": "Lien externe"
+    "view-preprint": "Lien externe",
+    "preprints": "Prépublications"
   },
   "create-author-dialog": {
     "title": "Créer un nouvel auteur"

--- a/resources/src/models/Preprint/Preprint.ts
+++ b/resources/src/models/Preprint/Preprint.ts
@@ -1,5 +1,4 @@
 import type { ManuscriptAuthorResource } from '../ManuscriptAuthor/ManuscriptAuthor'
-import type { PublicationResource } from '../Publication/Publication'
 import type { Resource, ResourceList } from '../Resource'
 import { http } from '@/api/http'
 import { SpatieQuery } from '@/api/SpatieQuery'

--- a/resources/src/models/Preprint/Preprint.ts
+++ b/resources/src/models/Preprint/Preprint.ts
@@ -1,0 +1,60 @@
+import type { ManuscriptAuthorResource } from '../ManuscriptAuthor/ManuscriptAuthor'
+import type { PublicationResource } from '../Publication/Publication'
+import type { Resource, ResourceList } from '../Resource'
+import { http } from '@/api/http'
+import { SpatieQuery } from '@/api/SpatieQuery'
+
+export interface Preprint {
+  manuscript_record_id: number
+  title: string
+  region_id: number
+  preprint_url: string
+  accepted_on: string
+  authors: ManuscriptAuthorResource[]
+}
+
+export type PreprintResource = Resource<Preprint>
+export type PreprintResourceList = ResourceList<Preprint>
+
+type PList = PreprintResourceList
+
+type PreprintQuerySort = 'accepted_on' | 'title'
+
+export class PreprintQuery extends SpatieQuery {
+  public filterId(id: number[]) {
+    this.filter('id', id)
+    return this
+  }
+
+  public filterUserId(id: number[]) {
+    this.filter('user_id', id)
+    return this
+  }
+
+  public filterAuthorID(authorId: number[]) {
+    this.filter('manuscriptAuthors.author_id', authorId)
+    return this
+  }
+
+  public filterTitle(title: string) {
+    this.filter('title', title)
+    return this
+  }
+
+  public sort(sort: PreprintQuerySort, direciton: 'asc' | 'desc') {
+    super.sort(sort, direciton)
+    return this
+  }
+}
+
+export class PreprintService {
+  /** Get a list of the preprints - accepted and published */
+  public static async list(query?: PreprintQuery) {
+    let url = 'api/preprints'
+    if (query) {
+      url += `?${query.toQueryString()}`
+    }
+    const response = await http.get<PList>(url)
+    return response.data
+  }
+}

--- a/resources/src/models/Preprint/components/PreprintList.vue
+++ b/resources/src/models/Preprint/components/PreprintList.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import type { PreprintResource } from '../Preprint'
+import DoiLink from '@/models/Publication/components/DoiLink.vue'
+
+defineProps<{
+  preprints: PreprintResource[]
+}>()
+
+const { t } = useI18n()
+
+function publishedYear(preprint: PreprintResource) {
+  if (preprint.data.accepted_on) {
+    return new Date(preprint.data.accepted_on).getFullYear()
+  }
+  return t('common.pending-publication')
+}
+</script>
+
+<template>
+  <q-list separator role="list">
+    <q-item
+      v-for="preprint in preprints"
+      :key="preprint.data.manuscript_record_id"
+    >
+      <q-item-section>
+        <q-item-label
+          class="text-body1 text-weight-medium text-primary"
+        >
+          {{ preprint.data.title }}
+        </q-item-label>
+        <q-item-label caption lines="2">
+          <template v-if="preprint.data.authors">
+            <template
+              v-if="
+                preprint.data.authors.length > 0
+              "
+            >
+              <span
+                v-for="(item, index) in preprint.data
+                  .authors"
+                :key="item.data.id"
+              >
+                <q-img
+                  v-if="item.data.author?.data.orcid"
+                  src="/assets/orcid/orcid.logo.icon.svg"
+                  width="15px"
+                />
+                {{ item.data.author?.data.last_name }},
+                {{ item.data.author?.data.first_name }}
+                <span
+                  v-if="
+                    index
+                      < preprint.data.authors
+                        ?.length
+                      - 1
+                  "
+                >;
+                </span>
+              </span>
+            </template>
+            <template v-else>
+              <span>{{ $t('common.no-authors') }}</span>
+            </template>
+          </template>
+        </q-item-label>
+        <q-item-label caption class="text-uppercase">
+          <div class="q-pt-sm flex">
+            <div>
+              {{ publishedYear(preprint) }}
+            </div>
+            <div class="q-mx-sm">
+              |
+            </div>
+            <div>URL/DOI: <DoiLink :doi="preprint.data.preprint_url" /></div>
+          </div>
+        </q-item-label>
+      </q-item-section>
+    </q-item>
+  </q-list>
+</template>
+
+<style scoped></style>

--- a/resources/src/models/Preprint/components/PreprintList.vue
+++ b/resources/src/models/Preprint/components/PreprintList.vue
@@ -8,9 +8,9 @@ defineProps<{
 
 const { t } = useI18n()
 
-function publishedYear(preprint: PreprintResource) {
+function publishedDate(preprint: PreprintResource) {
   if (preprint.data.accepted_on) {
-    return new Date(preprint.data.accepted_on).getFullYear()
+    return useLocaleDate(preprint.data.accepted_on)
   }
   return t('common.pending-publication')
 }
@@ -66,7 +66,7 @@ function publishedYear(preprint: PreprintResource) {
         <q-item-label caption class="text-uppercase">
           <div class="q-pt-sm flex">
             <div>
-              {{ publishedYear(preprint) }}
+              {{ publishedDate(preprint) }}
             </div>
             <div class="q-mx-sm">
               |
@@ -74,6 +74,20 @@ function publishedYear(preprint: PreprintResource) {
             <div>URL/DOI: <DoiLink :doi="preprint.data.preprint_url" /></div>
           </div>
         </q-item-label>
+      </q-item-section>
+      <q-item-section v-if="preprint.can?.view" side top>
+        <q-btn
+          size="sm"
+          outline
+          round
+          icon="mdi-file-document-arrow-right"
+          :to="{
+            name: 'manuscript.form',
+            params: { id: preprint.data.manuscript_record_id },
+          }"
+        >
+          <q-tooltip>{{ $t('common.go-to-manuscript-form') }}</q-tooltip>
+        </q-btn>
       </q-item-section>
     </q-item>
   </q-list>

--- a/resources/src/models/Preprint/views/PreprintListView.vue
+++ b/resources/src/models/Preprint/views/PreprintListView.vue
@@ -81,8 +81,11 @@ watch(authorId, () => {
 <template>
   <MainPageLayout :title="$t('common.preprints')">
     <div class="row q-gutter-lg q-col-gutter-lg flex">
-      <div class="col q-pr-lg">
+      <div class="col q-pr-lg q-pb-lg">
         <ContentCard secondary>
+          <template #title>
+            {{ $t('common.preprints') }}
+          </template>
           <template #title-right>
             <SearchInput
               v-model="search"

--- a/resources/src/models/Preprint/views/PreprintListView.vue
+++ b/resources/src/models/Preprint/views/PreprintListView.vue
@@ -1,20 +1,130 @@
 <script setup lang="ts">
 import type { PreprintResourceList } from '../Preprint'
-import { PreprintService } from '../Preprint'
+import { sharpWaterfallChart } from '@quasar/extras/material-icons-sharp'
+import ContentCard from '@/components/ContentCard.vue'
+import NoResultsFoundDiv from '@/components/NoResultsFoundDiv.vue'
+import PaginationDiv from '@/components/PaginationDiv.vue'
+import SearchInput from '@/components/SearchInput.vue'
+import MainPageLayout from '@/layouts/MainPageLayout.vue'
+import AuthorSelect from '@/models/Author/components/AuthorSelect.vue'
+import PreprintList from '../components/PreprintList.vue'
+import { PreprintQuery, PreprintService } from '../Preprint'
 
-const preprints = ref<PreprintResourceList | undefined>(undefined)
+const { t } = useI18n()
+
+const preprints = ref<PreprintResourceList>()
+const loading = ref(false)
+const currentPage = ref(1)
+
+// filter
+const showFilters = ref(false)
+const search = ref('')
+const authorId = ref<number | null>(null)
+const authorSelect = ref<InstanceType<typeof AuthorSelect> | null>(null)
+
+const filterCaption = computed(() => {
+  let caption = ''
+  if (authorId.value) {
+    const { first_name, last_name } = authorSelect?.value?.selectedAuthor?.data || {}
+    caption += `${t('common.by')} ${first_name || 'NA'} ${last_name || 'NA'} `
+  }
+  if (caption.length > 0)
+    caption = `${t('common.preprint')} ${caption.slice(0, -1)}`
+  else caption = t('common.no-filters-applied')
+  return caption
+})
 
 onMounted(() => {
   getPreprints()
 })
 
 async function getPreprints() {
-  preprints.value = await PreprintService.list()
+  if (loading.value)
+    return
+
+  let query = new PreprintQuery()
+
+  if (search?.value) {
+    query = query.filterTitle(search.value)
+  }
+
+  if (authorId.value) {
+    query = query.filterAuthorID([authorId.value])
+  }
+
+  query.paginate(currentPage.value, 10)
+
+  loading.value = true
+  preprints.value = await PreprintService.list(query)
+  loading.value = false
 }
+
+// Watchers
+watch(currentPage, () => {
+  getPreprints()
+})
+
+watchThrottled(
+  search,
+  () => {
+    currentPage.value = 1
+    getPreprints()
+  },
+  { throttle: 750 },
+)
+
+watch(authorId, () => {
+  currentPage.value = 1
+  getPreprints()
+})
 </script>
 
 <template>
-  <pre>{{ preprints }}</pre>
+  <MainPageLayout title="Preprints">
+    <div class="row q-gutter-lg q-col-gutter-lg flex">
+      <div class="col q-pr-lg">
+        <ContentCard secondary>
+          <template #title-right>
+            <SearchInput
+              v-model="search"
+              :label="$t('common.filter')"
+            />
+          </template>
+          <template #nav>
+            <q-expansion-item
+              v-model="showFilters"
+              icon="mdi-filter-variant"
+              :label="$t('common.filters')"
+              :caption="filterCaption"
+            >
+              <q-card-section class="column q-gutter-md">
+                <AuthorSelect
+                  ref="authorSelect"
+                  v-model="authorId"
+                  :label="$t('common.author')"
+                  :disable="loading"
+                  :hide-create-author-dialog="true"
+                />
+              </q-card-section>
+            </q-expansion-item>
+            <q-separator />
+          </template>
+          <template v-if="preprints?.data.length === 0">
+            <NoResultsFoundDiv />
+          </template>
+          <PreprintList :preprints="preprints?.data ?? []" />
+          <q-card-section>
+            <q-separator class="q-mb-md" />
+            <PaginationDiv
+              v-model="currentPage"
+              :meta="preprints?.meta ?? null"
+              :disable="loading"
+            />
+          </q-card-section>
+        </ContentCard>
+      </div>
+    </div>
+  </MainPageLayout>
 </template>
 
 <style scoped>

--- a/resources/src/models/Preprint/views/PreprintListView.vue
+++ b/resources/src/models/Preprint/views/PreprintListView.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { PreprintResourceList } from '../Preprint'
+import { PreprintService } from '../Preprint'
+
+const preprints = ref<PreprintResourceList | undefined>(undefined)
+
+onMounted(() => {
+  getPreprints()
+})
+
+async function getPreprints() {
+  preprints.value = await PreprintService.list()
+}
+</script>
+
+<template>
+  <pre>{{ preprints }}</pre>
+</template>
+
+<style scoped>
+
+</style>

--- a/resources/src/models/Preprint/views/PreprintListView.vue
+++ b/resources/src/models/Preprint/views/PreprintListView.vue
@@ -28,7 +28,7 @@ const filterCaption = computed(() => {
     caption += `${t('common.by')} ${first_name || 'NA'} ${last_name || 'NA'} `
   }
   if (caption.length > 0)
-    caption = `${t('common.preprint')} ${caption.slice(0, -1)}`
+    caption = `${t('common.preprints')} ${caption.slice(0, -1)}`
   else caption = t('common.no-filters-applied')
   return caption
 })
@@ -79,7 +79,7 @@ watch(authorId, () => {
 </script>
 
 <template>
-  <MainPageLayout title="Preprints">
+  <MainPageLayout :title="$t('common.preprints')">
     <div class="row q-gutter-lg q-col-gutter-lg flex">
       <div class="col q-pr-lg">
         <ContentCard secondary>

--- a/resources/src/models/Preprint/views/PreprintListView.vue
+++ b/resources/src/models/Preprint/views/PreprintListView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { PreprintResourceList } from '../Preprint'
-import { sharpWaterfallChart } from '@quasar/extras/material-icons-sharp'
 import ContentCard from '@/components/ContentCard.vue'
 import NoResultsFoundDiv from '@/components/NoResultsFoundDiv.vue'
 import PaginationDiv from '@/components/PaginationDiv.vue'

--- a/resources/src/models/Publication/views/PublicationPageView.vue
+++ b/resources/src/models/Publication/views/PublicationPageView.vue
@@ -1,21 +1,23 @@
 <script setup lang="ts">
+import type { PublicationResource } from '../Publication'
+import type { ManuscriptRecordMetadataResource } from '@/models/ManuscriptRecord/ManuscriptRecord'
 import type { Region } from '@/models/Region/Region'
+import { QForm, useQuasar } from 'quasar'
 import ContentCard from '@/components/ContentCard.vue'
 import DateInput from '@/components/DateInput.vue'
 import SavePageSticky from '@/components/SavePageSticky.vue'
 import WarnOnUnsavedChanges from '@/components/WarnOnUnsavedChanges.vue'
 import MainPageLayout from '@/layouts/MainPageLayout.vue'
 import JournalSelect from '@/models/Journal/components/JournalSelect.vue'
-import { type ManuscriptRecordMetadataResource, ManuscriptRecordService } from '@/models/ManuscriptRecord/ManuscriptRecord'
+import { ManuscriptRecordService } from '@/models/ManuscriptRecord/ManuscriptRecord'
 import ManagePublicationAuthorsCard from '@/models/PublicationAuthor/components/ManagePublicationAuthorsCard.vue'
 import RegionSelect from '@/models/Region/components/RegionSelect.vue'
-import { QForm, useQuasar } from 'quasar'
 import DoiInput from '../components/DoiInput.vue'
 import DoiLink from '../components/DoiLink.vue'
 import PublicationFileManagementCard from '../components/PublicationFileManagementCard.vue'
 import PublicationStatusBadge from '../components/PublicationStatusBadge.vue'
 import PublicationSupplementaryFileManagementCard from '../components/PublicationSupplementaryFileManagementCard.vue'
-import { type PublicationResource, PublicationService } from '../Publication'
+import { PublicationService } from '../Publication'
 
 const props = defineProps<{
   id: number

--- a/resources/src/models/Publication/views/PublicationsView.vue
+++ b/resources/src/models/Publication/views/PublicationsView.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import type { PublicationResourceList } from '../Publication'
+import { watchThrottled } from '@vueuse/core'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import ContentCard from '@/components/ContentCard.vue'
 import NoResultFoundDiv from '@/components/NoResultsFoundDiv.vue'
 import PaginationDiv from '@/components/PaginationDiv.vue'
@@ -7,9 +10,6 @@ import SearchInput from '@/components/SearchInput.vue'
 import MainPageLayout from '@/layouts/MainPageLayout.vue'
 import AuthorSelect from '@/models/Author/components/AuthorSelect.vue'
 import JournalSelect from '@/models/Journal/components/JournalSelect.vue'
-import { watchThrottled } from '@vueuse/core'
-import { computed, onMounted, ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import PublicationList from '../components/PublicationList.vue'
 import { PublicationQuery, PublicationService } from '../Publication'
 

--- a/resources/src/models/User/AuthenticatedUser.ts
+++ b/resources/src/models/User/AuthenticatedUser.ts
@@ -161,8 +161,12 @@ export class AuthenticatedUser implements IAuthenticatedUser {
         return locale === 'en' ? 'Director' : 'Directeur'
       case 'admin':
         return locale === 'en' ? 'Admin' : 'Administrateur'
+      case 'chief_editor':
+        return locale === 'en' ? 'Chief Editor' : 'Rédacteur en chef'
+      case 'editor':
+        return locale === 'en' ? 'Editor' : 'Éditeur'
       default:
-        return ''
+        return 'N/A'
     }
   }
 }

--- a/resources/src/models/User/AuthenticatedUser.ts
+++ b/resources/src/models/User/AuthenticatedUser.ts
@@ -144,7 +144,6 @@ export class AuthenticatedUser implements IAuthenticatedUser {
    * Does this user have the given role?
    *
    * @param role
-   * @returns
    */
   hasRole(role: AuthenticatedUserRoles): boolean {
     return this.roles.includes(role)

--- a/resources/src/models/User/AuthenticatedUser.ts
+++ b/resources/src/models/User/AuthenticatedUser.ts
@@ -1,7 +1,7 @@
+import type { UserResource } from './User'
 import type { AuthorResource } from '@/models/Author/Author'
 import type { Resource, ResourceList, SensitivityLabel } from '@/models/Resource'
 import type { Locale } from '@/stores/LocaleStore'
-import type { UserResource } from './User'
 import { http } from '@/api/http'
 
 export type AuthenticatedUserResource = Resource<IAuthenticatedUser>
@@ -73,6 +73,7 @@ export type AuthenticatedUserPermissions =
   | 'create_author_employments'
   | 'complete_interntal_management_review'
   | 'view_any_users'
+  | 'view_any_manuscript_record'
   | 'publish_internal_reports'
   | 'update_publications'
 

--- a/resources/src/router/routes.ts
+++ b/resources/src/router/routes.ts
@@ -147,6 +147,12 @@ const routes: RouteRecordRaw[] = [
         meta: { requiresAuth: true },
       },
       {
+        path: '/preprints',
+        component: () =>
+          import('@/models/Preprint/views/PreprintListView.vue'),
+        meta: { requiresAuth: true },
+      },
+      {
         path: '/sensitive-issues',
         component: UnderConstruction,
         meta: { requiresAuth: true },

--- a/routes/api.php
+++ b/routes/api.php
@@ -131,7 +131,7 @@ Route::middleware(['auth:sanctum'])->group(function () {
         Route::put('manuscript-records/{manuscriptRecord}/accepted', 'accepted');
     });
 
-    Route::controller(PreprintController::class)->group(function() {
+    Route::controller(PreprintController::class)->group(function () {
         Route::get('/preprints', 'index');
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\OpenAI\GeneratePLSController;
 use App\Http\Controllers\Orcid\FullFlowController;
 use App\Http\Controllers\Orcid\RevokeTokenController;
 use App\Http\Controllers\OrganizationController;
+use App\Http\Controllers\PreprintController;
 use App\Http\Controllers\PublicationAuthorController;
 use App\Http\Controllers\PublicationController;
 use App\Http\Controllers\PublicationFileController;
@@ -128,6 +129,10 @@ Route::middleware(['auth:sanctum'])->group(function () {
         Route::put('manuscript-records/{manuscriptRecord}/submitted', 'submitted');
         Route::put('manuscript-records/{manuscriptRecord}/submitted-to-preprint', 'submittedToPreprint');
         Route::put('manuscript-records/{manuscriptRecord}/accepted', 'accepted');
+    });
+
+    Route::controller(PreprintController::class)->group(function() {
+        Route::get('/preprints', 'index');
     });
 
     Route::controller(ManuscriptRecordSharingController::class)->group(function () {

--- a/tests/Feature/PreprintListTest.php
+++ b/tests/Feature/PreprintListTest.php
@@ -21,6 +21,4 @@ test('a user can list the published preprints', function () {
     $response = $this->actingAs($user)->getJson('/api/preprints?limit=2');
     $response->assertStatus(200);
     expect($response->json('data'))->toHaveCount(2);
-
-    dd($response->json('data'));
 });

--- a/tests/Feature/PreprintListTest.php
+++ b/tests/Feature/PreprintListTest.php
@@ -17,7 +17,7 @@ test('a user can list the published preprints', function () {
     $response->assertStatus(200);
     expect($response->json('data'))->toHaveCount(5);
 
-    //limit to 2..
+    // limit to 2..
     $response = $this->actingAs($user)->getJson('/api/preprints?limit=2');
     $response->assertStatus(200);
     expect($response->json('data'))->toHaveCount(2);

--- a/tests/Feature/PreprintListTest.php
+++ b/tests/Feature/PreprintListTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\ManuscriptRecord;
+use App\Models\User;
+
+test('a user can list the published preprints', function () {
+
+    $user = User::factory()->create();
+
+    // need to be logged in
+    $response = $this->getJson('/api/preprints');
+    $response->assertUnauthorized();
+
+    ManuscriptRecord::factory()->publishedPreprint()->count(5)->create();
+
+    $response = $this->actingAs($user)->getJson('/api/preprints');
+    $response->assertStatus(200);
+    expect($response->json('data'))->toHaveCount(5);
+
+    //limit to 2..
+    $response = $this->actingAs($user)->getJson('/api/preprints?limit=2');
+    $response->assertStatus(200);
+    expect($response->json('data'))->toHaveCount(2);
+
+    dd($response->json('data'));
+});


### PR DESCRIPTION
This pull request introduces a new feature for managing and displaying preprints, along with related updates to permissions, policies, and UI components. The changes include backend support for querying and displaying preprints, frontend components for listing and filtering preprints, and updates to user permissions to allow specific roles to view manuscript records.

### Backend Changes:
* Added `VIEW_ANY_MANUSCRIPT_RECORD` permission to `UserPermission` and assigned it to `DIRECTOR` and `EDITOR` roles in `UserRole`. This enables these roles to view manuscript records under certain conditions. [[1]](diffhunk://#diff-99968159b97534019fc39ed29b4cfbf9a9cd706252dd2b3dc06992889aabaa50R19) [[2]](diffhunk://#diff-ffcc637fccc75589645efdbb94822f3f5b5e04329b460fac8c4b97a8c024357aR30) [[3]](diffhunk://#diff-ffcc637fccc75589645efdbb94822f3f5b5e04329b460fac8c4b97a8c024357aR45)
* Implemented `PreprintController`, `PreprintResource`, and `PreprintListQuery` to handle preprint-related API endpoints, resource transformation, and query building. [[1]](diffhunk://#diff-81c9b0b4f46e3d224887d48acf6d6e0d18878e8faf69817426a71407a84a9ddeR1-R25) [[2]](diffhunk://#diff-c9f98010a893380de94a3a78c85be6d669599a24018e19d78bcf26e2f4b0df4dR1-R39) [[3]](diffhunk://#diff-041c8df66e8fa3b82b9a9feb984b1057fa089f151f31cc8d554391f3fd21701dR1-R40)
* Updated `ManuscriptRecordPolicy` to allow users with the new permission to view non-draft manuscript records.
* Enhanced `ManuscriptRecordFactory` and `LocalTestDataSeeder` to support creating and seeding preprint data for testing and development. [[1]](diffhunk://#diff-5934698aaab25cd2fb87ae36ff01bed1b4ffba18e134aec02a81e84d785f4ce8R120-R133) [[2]](diffhunk://#diff-fc1c68b25fa7049fc0e19240f8e25b6b8f729f30b139992520e3e8255c4cdae8R176-R178)

### Frontend Changes:
* Added Vue components (`PreprintList`, `PreprintListView`) and services (`PreprintService`, `PreprintQuery`) to display and filter preprints in the UI. [[1]](diffhunk://#diff-d9b28db63a9c6305baa464c5d00ad64ae3db1367267ab747f46c47454719d616R1-R96) [[2]](diffhunk://#diff-a040549223339876a16914236547918712451147afca22e51ae079318b932f91R1-R134) [[3]](diffhunk://#diff-fd620eaa8738a7f5b9c0161d29e4f35ddca3e3ef39a9074a49a981ef18422863R1-R59)
* Updated `MainDrawer.vue` to include a new menu item for navigating to the preprints page.
* Added translations for "Preprints" in English and French locale files. [[1]](diffhunk://#diff-f41d834e4b61f15e83c95823f1fa33d2eaf43bdf4ff3a93def46793f9011810aL298-R299) [[2]](diffhunk://#diff-418711763e6501955b074eea5a0b626108b1b08b203a3ee2856a9bf35f4c8f08L294-R295)

### Codebase Improvements:
* Minor code cleanup and import reordering in several Vue components for better readability and organization. [[1]](diffhunk://#diff-7fa512378c3a07eabc44d1e042d5652fabf4d5bbb2d716dd07ad8cd7cf0f416eL2-R3) [[2]](diffhunk://#diff-533321bfb2eb25c56baaac44a6f79d4ace10e9b5d32c8cbef4d1b96ccf948dc0R2-R20) [[3]](diffhunk://#diff-ad0d77ac811023fa83ed890bc94fed3fb28f2482001d32812a90e818c27e8a97R3-L12) [[4]](diffhunk://#diff-7b8fe208320ab7c58b017cd089d822e295f2f7f1cf16a255dd7772128c4090f4R1-L4)