### PR TITLE
feat: update emails  (minor edits)

### DIFF
--- a/resources/views/components/email/decision-expected-by.blade.php
+++ b/resources/views/components/email/decision-expected-by.blade.php
@@ -2,9 +2,9 @@
 @if($locale == 'fr')
     @if($managementReviewStep->status == App\Enums\ManagementReviewStepStatus::PENDING)
         @if($managementReviewStep->decision_expected_by === null)
-        Une réponse à cette révision est attendue dans un délai raisonnable.
+        Une réponse à cette révision est attendue dans un délai raisonnable, comme indiqué dans la Politique nationale de publication scientifique du ministère des Pêches et des Océans Canada.
         @else
-        Une réponse à cette révision est attendue d'ici le {{ $managementReviewStep->decision_expected_by->locale('fr_CA')->isoFormat('LL') }}.
+        Une réponse à cette révision est requise d'ici le {{ $managementReviewStep->decision_expected_by->locale('fr_CA')->isoFormat('LL') }}.
         @endif
     @elseif($managementReviewStep->status == App\Enums\ManagementReviewStepStatus::ON_HOLD)
     Une réponse à cette révision est actuellement en attente jusqu'à ce que les commentaires soient traités par les auteurs.
@@ -12,9 +12,9 @@
 @else
     @if($managementReviewStep->status == App\Enums\ManagementReviewStepStatus::PENDING)
         @if($managementReviewStep->decision_expected_by === null)
-        A response to this review is expected in a timely manner.
+        A response to this review is expected in a timely manner, as detailed in the Fisheries and Oceans Canada National Policy on Science Publications.
         @else
-        A response to this review is expected by {{ $managementReviewStep->decision_expected_by->locale('en_CA')->isoFormat('LL') }}.
+        A response to this review is required by {{ $managementReviewStep->decision_expected_by->locale('en_CA')->isoFormat('LL') }}.
         @endif
     @elseif($managementReviewStep->status == App\Enums\ManagementReviewStepStatus::ON_HOLD)
     A response to this review is currently on hold until the comments are addressed by the authors.

--- a/resources/views/mail/manuscriptRecord/manuscript-management-review-complete.blade.php
+++ b/resources/views/mail/manuscriptRecord/manuscript-management-review-complete.blade.php
@@ -3,14 +3,14 @@
 
 *(le français suit)*
 
-Your manuscripts' management review is complete.
+Your manuscript's management review is complete.
 
 You may proceed with the publication process for the manuscript titled "{{ $manuscriptRecord->title }}".
 
-Please ensure that the text “Fisheries and Oceans Canada” appears as an author's affiliation in order to ensure that publications by DFO authors are retrievable in online searches and discovered for bibliometric analysis.
+Please include “Fisheries and Oceans Canada” as your author affiliation to ensure that publications by DFO authors are retrievable in online searches and discovered for bibliometric analysis.
 
-Once published, please ensure that you update the manuscript record with your publication information in the Open Science Portal.
-If you decide to no longer publish this manuscript, update the manuscript record status to "withdrawn".
+Once published, please ensure that you update this entry in the Open Science Portal.
+If you no longer wish to publish this manuscript, please update the manuscript record status to "withdrawn".
 
 <x-mail::button :url="config('app.frontend_url').'#/auth/login?email='.$manuscriptRecord->user->email.'&redirect=/manuscript/'.$manuscriptRecord->id.'/reviews'">
 Update Manuscript Status
@@ -26,13 +26,13 @@ La révision par le gestionnaire de votre manuscrit est terminée.
 
 Vous pouvez procéder à la publication du manuscrit intitulé "{{ $manuscriptRecord->title }}".
 
-Veuillez vous assurer que le texte "Fisheries and Oceans Canada" apparaît comme affiliation de l'auteur afin de s'assurer que les publications des auteurs du MPO sont repérables dans les recherches en ligne et découvertes pour l'analyse bibliométrique.
+Veuillez utiliser "Fisheries and Oceans Canada" comme affiliation de l'auteur afin de s'assurer que les publications des auteurs du MPO sont repérables dans les recherches en ligne et découvertes pour l'analyse bibliométrique.
 
-Une fois le manuscrit publié, veuillez tenir à jour les détails de publications de votre manuscrit dans le portail.
-Si vous décidez de ne plus publier ce manuscrit, mettez à jour le statut du registre de manuscrit avec la mention "retiré".
+Une fois le manuscrit publié, veuillez vous assurer de mettre à jour cette entrée dans le Portail de science ouverte.
+Si vous ne souhaitez plus publier ce manuscrit, veuillez mettre à jour le statut de l'enregistrement du manuscrit à "retiré".
 
-<x-mail::button :url="config('app.frontend_url').'#/auth/login?email='.$manuscriptRecord->user->email.'&redirect=/manuscript/'.$manuscriptRecord->id">
-Mise à jour du statut du manuscrit
+<x-mail::button :url="config('app.frontend_url').'#/auth/login?email='.$manuscriptRecord->user->email.'&redirect=/manuscript/'.$manuscriptRecord->id.'/reviews'">
+Mettre à jour le statut du manuscrit
 </x-mail::button>
 
 <x-email.regards locale="fr" />

--- a/resources/views/mail/review-step-notification-mail.blade.php
+++ b/resources/views/mail/review-step-notification-mail.blade.php
@@ -5,7 +5,8 @@
 
 @if($previousStep->decision == App\Enums\ManagementReviewStepDecision::REVISION)
 {{ $previousStep->user->fullName }} has flagged the manuscript titled "{{ $manuscriptRecord->title }}". Please review and address the comments below.
-<p>When ready, please click the button below to restart the management review. Please note that you can upload a revised version of the manuscript record in the portal.</p>
+<p>Completion of the management review is pending your revisions, as per the comments below.</p>
+<p>When ready, please click the button below to upload your revised manuscript and to restart the management review.</p>
 @else
 {{ $previousStep->user->fullName }} has identified you as the next management reviewer for the manuscript titled "{{ $manuscriptRecord->title }}".
 @endif
@@ -44,7 +45,8 @@ Review Manuscript
 
 @if($previousStep->decision == App\Enums\ManagementReviewStepDecision::REVISION)
 {{ $previousStep->user->fullName }} a signalé des révisions nécessaires sur le manuscrit intitulé "{{ $manuscriptRecord->title }}". Veuillez examiner et traiter les commentaires ci-dessous.
-<p>Lorsque vous êtes prêt, veuillez cliquer sur le bouton ci-dessous pour redémarrer la révision de gestion. Veuillez noter que vous pouvez télécharger une version révisée du registre de manuscrit dans le portail.</p>
+<p>La révision de gestion est en attente de vos modifications, comme indiqué dans les commentaires ci-dessous.</p>
+<p>Lorsque vous êtes prêt, veuillez cliquer sur le bouton ci-dessous pour télécharger votre manuscrit révisé et redémarrer la révision de gestion.</p>
 @else
 {{ $previousStep->user->fullName }} vous a identifié comme le prochain gestionnaire de la révision pour le manuscrit intitulé "{{ $manuscriptRecord->title }}".
 @endif


### PR DESCRIPTION
This pull request focuses on improving the clarity and consistency of language in several email templates, as well as ensuring alignment with organizational policies. The changes primarily involve rewording text for better readability and adherence to formal guidelines in both English and French versions of the templates.

### Updates to email templates for clarity and policy alignment:

#### Decision expected notifications:
* Updated phrasing in `resources/views/components/email/decision-expected-by.blade.php` to reference the Fisheries and Oceans Canada National Policy on Science Publications and clarified that responses are "required" rather than "expected" by a specific date.

#### Management review completion notifications:
* Improved phrasing in `resources/views/mail/manuscriptRecord/manuscript-management-review-complete.blade.php` to emphasize the inclusion of "Fisheries and Oceans Canada" as an author affiliation and streamlined instructions for updating publication details in the Open Science Portal. [[1]](diffhunk://#diff-cfaca65938527c6c0a8f544ce577c359b4a591a1512f9fa6188d032f06e4658dL6-R13) [[2]](diffhunk://#diff-cfaca65938527c6c0a8f544ce577c359b4a591a1512f9fa6188d032f06e4658dL29-R35)

#### Review step notifications:
* Revised text in `resources/views/mail/review-step-notification-mail.blade.php` to clarify that management review completion is pending revisions and to provide clearer instructions for uploading a revised manuscript. [[1]](diffhunk://#diff-11ac01d25261f6715f5ab2628355ca6ad3b1677cbc2cd207d4a16db4eabd54c9L8-R9) [[2]](diffhunk://#diff-11ac01d25261f6715f5ab2628355ca6ad3b1677cbc2cd207d4a16db4eabd54c9L47-R49)