### PR TITLE
Fix funding source title column truncation

### DIFF
--- a/database/migrations/2026_02_27_192449_increase_funding_sources_title_column_length.php
+++ b/database/migrations/2026_02_27_192449_increase_funding_sources_title_column_length.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('funding_sources', function (Blueprint $table) {
+            $table->string('title', 255)->change();
+        });
+    }
+};

--- a/tests/Feature/Models/ManuscriptRecordFundingSourceTest.php
+++ b/tests/Feature/Models/ManuscriptRecordFundingSourceTest.php
@@ -69,6 +69,31 @@ test('a user can update an existing funding source on their manuscript', functio
     ray($response->json());
 });
 
+test('a user cannot create a funding source with a title longer than 255 characters', function (): void {
+    $user = User::factory()->create();
+    $manuscript = ManuscriptRecord::factory()->create(['user_id' => $user->id]);
+    $funder = \App\Models\Funder::factory()->create();
+
+    $this->actingAs($user)->postJson('/api/manuscript-records/'.$manuscript->id.'/funding-sources', [
+        'funder_id' => $funder->id,
+        'title' => str_repeat('a', 256),
+        'description' => 'A description',
+    ])->assertUnprocessable()
+        ->assertJsonValidationErrors('title');
+});
+
+test('a user can create a funding source with a title up to 255 characters', function (): void {
+    $user = User::factory()->create();
+    $manuscript = ManuscriptRecord::factory()->create(['user_id' => $user->id]);
+    $funder = \App\Models\Funder::factory()->create();
+
+    $this->actingAs($user)->postJson('/api/manuscript-records/'.$manuscript->id.'/funding-sources', [
+        'funder_id' => $funder->id,
+        'title' => str_repeat('a', 255),
+        'description' => 'A description',
+    ])->assertCreated();
+});
+
 test('a user can delete a funding source on their manuscript', function (): void {
     $unauthorizedUser = User::factory()->create();
     $authorizedUser = User::factory()->create();


### PR DESCRIPTION
## Summary
- Increased `funding_sources.title` column from `varchar(125)` to `varchar(255)` to match existing validation rules
- Added tests for title length validation on manuscript record funding sources

## Test plan
- [x] Existing funding source tests pass
- [x] New tests verify title max length validation (255 accepted, 256 rejected)