### PR TITLE
feat: allow publication authors to publish their publications

### DIFF
--- a/app/Policies/PublicationPolicy.php
+++ b/app/Policies/PublicationPolicy.php
@@ -149,19 +149,25 @@ class PublicationPolicy
     /** Can the user publish this publication */
     public function publish(User $user, Publication $publication): bool
     {
-
         $isDfoSeries = $publication->journal->publisher == Journal::$dfoPublisher;
 
         if ($user->hasPermissionTo(UserPermission::PUBLISH_INTERNAL_REPORTS)) {
             return true;
         }
 
-        // is the user the owner of the publication
-        if ($user->id === $publication->user_id) {
-            return ! $isDfoSeries;
+        if ($isDfoSeries) {
+            return false;
         }
 
-        return false;
+        // is the user the owner of the publication
+        if ($user->id === $publication->user_id) {
+            return true;
+        }
+
+        // if the user is an author on the publication, they can publish it
+        $authorUserIds = $publication->publicationAuthors->pluck('author.user_id');
+
+        return $authorUserIds->contains($user->id);
     }
 
     /**

--- a/tests/Feature/Policies/PublicationPolicyTest.php
+++ b/tests/Feature/Policies/PublicationPolicyTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Enums\Permissions\UserRole;
+use App\Models\Author;
 use App\Models\Publication;
+use App\Models\PublicationAuthor;
 use App\Models\Region;
 use App\Models\User;
 
@@ -92,4 +94,37 @@ test('user with multiple regional editor roles can update publications in all th
     expect($multiRegionalEditor->can('update', $nflPub))->toBeTrue();
     expect($multiRegionalEditor->can('update', $marPub))->toBeTrue();
     expect($multiRegionalEditor->can('update', $glfPub))->toBeFalse();
+});
+
+test('publication author can publish the publication', function (): void {
+    $authorUser = User::factory()->create();
+    $author = Author::factory()->create(['user_id' => $authorUser->id]);
+    $publication = Publication::factory()->create();
+
+    PublicationAuthor::factory()->create([
+        'publication_id' => $publication->id,
+        'author_id' => $author->id,
+    ]);
+
+    expect($authorUser->can('publish', $publication))->toBeTrue();
+});
+
+test('publication author cannot publish a DFO series publication', function (): void {
+    $authorUser = User::factory()->create();
+    $author = Author::factory()->create(['user_id' => $authorUser->id]);
+    $publication = Publication::factory()->dfoSeries()->create();
+
+    PublicationAuthor::factory()->create([
+        'publication_id' => $publication->id,
+        'author_id' => $author->id,
+    ]);
+
+    expect($authorUser->can('publish', $publication))->toBeFalse();
+});
+
+test('non-author regular user cannot publish a publication', function (): void {
+    $user = User::factory()->create();
+    $publication = Publication::factory()->create();
+
+    expect($user->can('publish', $publication))->toBeFalse();
 });


### PR DESCRIPTION
## Summary

- `PublicationPolicy::publish()` now grants publish access to any user linked as a `PublicationAuthor` on the publication, matching the existing owner behaviour
- DFO series publications still require the `PUBLISH_INTERNAL_REPORTS` permission (authors are blocked like owners)
- Refactored the DFO series check to an early return to simplify the logic

## Test plan

- [x] Publication author can publish their publication
- [x] Publication author cannot publish a DFO series publication
- [x] Non-author regular user still cannot publish