### PR TITLE
fix: convert cached collections to arrays on /stats route

### DIFF
--- a/app/Http/Controllers/PublicStatsController.php
+++ b/app/Http/Controllers/PublicStatsController.php
@@ -52,7 +52,8 @@ class PublicStatsController extends Controller
                     ->select(['organizations.id', 'name_en', 'name_fr', 'ror_identifier'])
                     ->inRandomOrder()
                     ->limit(5)
-                    ->get(),
+                    ->get()
+                    ->toArray(),
                 'recent_publications' => Publication::query()
                     ->where('status', PublicationStatus::PUBLISHED)
                     ->whereNotNull('doi')
@@ -68,8 +69,9 @@ class PublicStatsController extends Controller
                         'journal' => $pub->journal->only(['id', 'title']),
                         'authors' => $pub->publicationAuthors
                             ->map(fn ($pa): PublicAuthorResource => new PublicAuthorResource($pa->author))
-                            ->values(),
-                    ]),
+                            ->values()
+                    ->toArray(),
+                ]),
             ];
         });
 

--- a/app/Http/Controllers/PublicStatsController.php
+++ b/app/Http/Controllers/PublicStatsController.php
@@ -70,8 +70,8 @@ class PublicStatsController extends Controller
                         'authors' => $pub->publicationAuthors
                             ->map(fn ($pa): PublicAuthorResource => new PublicAuthorResource($pa->author))
                             ->values()
-                    ->toArray(),
-                ]),
+                            ->all(),
+                    ]),
             ];
         });
 


### PR DESCRIPTION
## Summary
- `external_organizations` and `recent_publications` were being cached as Eloquent/Support Collection objects
- A recent Laravel framework change tightened object deserialization in cache, causing `__PHP_Incomplete_Class_Name` errors on the `/stats` route
- Since the cached data is only ever serialized to JSON, converting to plain arrays before caching is the correct fix

## Test plan
- [ ] Hit `/api/stats` and confirm `external_organizations` and `recent_publications` return valid data
- [ ] Run `php artisan cache:forget public-stats` on bprod to clear the stale cache entry