### PR TITLE
fix(librarium): user view activity log crashes

### DIFF
--- a/app/Filament/Resources/Users/Pages/ViewUserLogs.php
+++ b/app/Filament/Resources/Users/Pages/ViewUserLogs.php
@@ -22,7 +22,7 @@ class ViewUserLogs extends ManageRelatedRecords
 {
     protected static string $resource = UserResource::class;
 
-    protected static string $relationship = 'actions';
+    protected static string $relationship = 'activitiesAsCauser';
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-rectangle-stack';
 

--- a/tests/Feature/Librarium/UserResourceTest.php
+++ b/tests/Feature/Librarium/UserResourceTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature\Librarium;
 
 use App\Filament\Resources\Users\Pages\EditUser;
 use App\Filament\Resources\Users\Pages\ListUsers;
+use App\Filament\Resources\Users\Pages\ViewUserLogs;
 use App\Models\User;
+use Spatie\Activitylog\Models\Activity;
 
 describe('Access control for User Resources', function (): void {
 
@@ -27,6 +29,23 @@ describe('Access control for User Resources', function (): void {
 
     it('Can render the index page', function (): void {
         $this->actingAs($this->admin)->get(ListUsers::getUrl())->assertOk();
+    });
+
+    it('Can render the user logs page', function (): void {
+        activity()
+            ->causedBy($this->record)
+            ->event('updated')
+            ->withProperties(['changed' => ['email' => $this->record->email]])
+            ->log('user.updated');
+
+        $relatedActivities = Activity::query()
+            ->where('causer_id', $this->record->id)
+            ->where('causer_type', User::class)
+            ->get();
+
+        $this->actingAs($this->admin)->livewire(ViewUserLogs::class, ['record' => $this->record->getRouteKey()])
+            ->assertOk()
+            ->assertCanSeeTableRecords($relatedActivities);
     });
 
     it('Can render logout button', function (): void {})->todo();


### PR DESCRIPTION

## **Description**

### Problem
The `ViewUserLogs` page attempts to load activity records using an invalid relationship name: `'actions'`. The User model does not define an `'actions'` relationship, which would cause the page to fail or display no records.

### Solution
Change the relationship reference to `'activitiesAsCauser'`, which is the correct relationship provided by Spatie's `CausesActivity` trait on the User model. This relationship retrieves all Activity records where the user is the causer (i.e., the user who performed the logged action).

### Change Details
- **File modified:** `app/Filament/Resources/Users/Pages/ViewUserLogs.php`
- **Line 25:** `'actions'` → `'activitiesAsCauser'`
- **Impact:** Fixes the User Activities log view in Filament admin panel

### Context
- The User model uses `CausesActivity` from Spatie's Activity Log package (lines 30, 114)
- The `activitiesAsCauser` relationship is documented in the User model's PHPDoc (line 49)
- The ViewUserLogs page correctly configures the table, filters, and infolist for displaying Activity records
- The only issue was the incorrect relationship name passed to the ManageRelatedRecords page

---

## **Testing**
1. Navigate to the Users resource in Filament
2. Open a user record
3. Click the "View Activities" tab
4. Verify that the user's activity logs display correctly without errors