### PR TITLE
feat(mmr) - unsubmit from manuscript management review 

### DIFF
--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -59,6 +59,6 @@ class UnsubmitManuscriptManagementReview
                 ->log('Manuscript was unsubmitted for manuscript management review');
         });
 
-        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUsers, $unsubmittedBy));
+        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUsers, $unsubmittedBy, $reason));
     }
 }

--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -12,7 +12,7 @@ class UnsubmitManuscriptManagementReview
     {
         if ($manuscriptRecord->status !== ManuscriptRecordStatus::IN_REVIEW) {
             throw new \InvalidArgumentException(
-                "Only manuscript records in review can be unsubmitted."
+                'Only manuscript records in review can be unsubmitted.'
             );
         }
 
@@ -25,10 +25,10 @@ class UnsubmitManuscriptManagementReview
             $manuscriptRecord->refresh();
 
             activity()
-            ->performedOn($manuscriptRecord)
-            ->causedBy(auth()->user())
-            ->event('unsubmitted')
-            ->log('Manuscript was unsubmitted for manuscript management review');
+                ->performedOn($manuscriptRecord)
+                ->causedBy(auth()->user())
+                ->event('unsubmitted')
+                ->log('Manuscript was unsubmitted for manuscript management review');
         });
-    } 
+    }
 }

--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -17,9 +17,10 @@ class UnsubmitManuscriptManagementReview
             );
         }
 
-        $reviewUser = $manuscriptRecord->managementReviewSteps()->latest()->first()->user; // store the review user for contact before deleting the review steps
+        $reviewUsers = $manuscriptRecord->managementReviewSteps->values(); // store the reviewer steps for contact before deleting the review steps
 
         DB::transaction(function () use ($manuscriptRecord): void {
+            $manuscriptRecord->managementReviewSteps()->update(['previous_step_id' => null]);
             $manuscriptRecord->managementReviewSteps()->delete();
 
             $manuscriptRecord->status = ManuscriptRecordStatus::DRAFT;
@@ -34,7 +35,7 @@ class UnsubmitManuscriptManagementReview
                 ->log('Manuscript was unsubmitted for manuscript management review');
         });
 
-        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUser)); // trigger email reviewer and author process
+        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUsers)); // trigger email reviewer and author process
 
     }
 }

--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -20,9 +20,18 @@ class UnsubmitManuscriptManagementReview
         $old = [
             'status' => $manuscriptRecord->status->value,
             'sent_for_review_at' => $manuscriptRecord->sent_for_review_at,
-        ]; // Store old status for activity log
-        $reason = trim($reason); // Ensure reason is not just whitespace
-        $reviewUsers = $manuscriptRecord->managementReviewSteps->values(); // store the reviewer steps for contact before deleting the review steps
+            'management_review_steps' => $manuscriptRecord->managementReviewSteps
+                ->map(fn ($reviewStep): array => [
+                    'user_id' => $reviewStep->user_id,
+                    'decision' => $reviewStep->decision?->value,
+                    'comments' => $reviewStep->comments,
+                ])
+                ->values()
+                ->all(),
+        ];
+
+        $reason = trim($reason);
+        $reviewUsers = $manuscriptRecord->managementReviewSteps->values();
 
         DB::transaction(function () use ($manuscriptRecord, $reason, $old): void {
             $manuscriptRecord->managementReviewSteps()->update(['previous_step_id' => null]);
@@ -30,6 +39,7 @@ class UnsubmitManuscriptManagementReview
 
             $manuscriptRecord->status = ManuscriptRecordStatus::DRAFT;
             $manuscriptRecord->sent_for_review_at = null;
+            $manuscriptRecord->unlockManuscriptFiles();
             $manuscriptRecord->save();
             $manuscriptRecord->refresh();
 
@@ -48,7 +58,6 @@ class UnsubmitManuscriptManagementReview
                 ->log('Manuscript was unsubmitted for manuscript management review');
         });
 
-        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUsers)); // trigger email reviewer and author process
-
+        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUsers));
     }
 }

--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
 
 class UnsubmitManuscriptManagementReview
 {
-    public static function handle(ManuscriptRecord $manuscriptRecord): void
+    public static function handle(ManuscriptRecord $manuscriptRecord, string $reason): void
     {
         if ($manuscriptRecord->status !== ManuscriptRecordStatus::IN_REVIEW) {
             throw new \InvalidArgumentException(
@@ -17,9 +17,14 @@ class UnsubmitManuscriptManagementReview
             );
         }
 
+        $old = [
+            'status' => $manuscriptRecord->status->value,
+            'sent_for_review_at' => $manuscriptRecord->sent_for_review_at,
+        ]; // Store old status for activity log
+        $reason = trim($reason); // Ensure reason is not just whitespace
         $reviewUsers = $manuscriptRecord->managementReviewSteps->values(); // store the reviewer steps for contact before deleting the review steps
 
-        DB::transaction(function () use ($manuscriptRecord): void {
+        DB::transaction(function () use ($manuscriptRecord, $reason, $old): void {
             $manuscriptRecord->managementReviewSteps()->update(['previous_step_id' => null]);
             $manuscriptRecord->managementReviewSteps()->delete();
 
@@ -32,6 +37,14 @@ class UnsubmitManuscriptManagementReview
                 ->performedOn($manuscriptRecord)
                 ->causedBy(auth()->user())
                 ->event('unsubmitted')
+                ->withProperties([
+                    'reason' => $reason,
+                    'old' => $old,
+                    'attributes' => [
+                        'status' => $manuscriptRecord->status->value,
+                        'sent_for_review_at' => $manuscriptRecord->sent_for_review_at,
+                    ],
+                ])
                 ->log('Manuscript was unsubmitted for manuscript management review');
         });
 

--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\ManuscriptRecordStatus;
+use App\Models\ManuscriptRecord;
+use Illuminate\Support\Facades\DB;
+
+class UnsubmitManuscriptManagementReview
+{
+    public static function handle(ManuscriptRecord $manuscriptRecord): void
+    {
+        if ($manuscriptRecord->status !== ManuscriptRecordStatus::IN_REVIEW) {
+            throw new \InvalidArgumentException(
+                "Only manuscript records in review can be unsubmitted."
+            );
+        }
+
+        DB::transaction(function () use ($manuscriptRecord): void {
+            $manuscriptRecord->managementReviewSteps()->delete();
+
+            $manuscriptRecord->status = ManuscriptRecordStatus::DRAFT;
+            $manuscriptRecord->sent_for_review_at = null;
+            $manuscriptRecord->save();
+            $manuscriptRecord->refresh();
+
+            activity()
+            ->performedOn($manuscriptRecord)
+            ->causedBy(auth()->user())
+            ->event('unsubmitted')
+            ->log('Manuscript was unsubmitted for manuscript management review');
+        });
+    } 
+}

--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -32,6 +32,7 @@ class UnsubmitManuscriptManagementReview
 
         $reason = trim($reason);
         $reviewUsers = $manuscriptRecord->managementReviewSteps->values();
+        $unsubmittedBy = auth()->user();
 
         DB::transaction(function () use ($manuscriptRecord, $reason, $old): void {
             $manuscriptRecord->managementReviewSteps()->update(['previous_step_id' => null]);
@@ -58,6 +59,6 @@ class UnsubmitManuscriptManagementReview
                 ->log('Manuscript was unsubmitted for manuscript management review');
         });
 
-        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUsers));
+        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUsers, $unsubmittedBy));
     }
 }

--- a/app/Actions/UnsubmitManuscriptManagementReview.php
+++ b/app/Actions/UnsubmitManuscriptManagementReview.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use App\Enums\ManuscriptRecordStatus;
+use App\Events\ManuscriptManagementReviewUnsubmittedEvent;
 use App\Models\ManuscriptRecord;
 use Illuminate\Support\Facades\DB;
 
@@ -15,6 +16,8 @@ class UnsubmitManuscriptManagementReview
                 'Only manuscript records in review can be unsubmitted.'
             );
         }
+
+        $reviewUser = $manuscriptRecord->managementReviewSteps()->latest()->first()->user; // store the review user for contact before deleting the review steps
 
         DB::transaction(function () use ($manuscriptRecord): void {
             $manuscriptRecord->managementReviewSteps()->delete();
@@ -30,5 +33,8 @@ class UnsubmitManuscriptManagementReview
                 ->event('unsubmitted')
                 ->log('Manuscript was unsubmitted for manuscript management review');
         });
+
+        event(new ManuscriptManagementReviewUnsubmittedEvent($manuscriptRecord, $reviewUser)); // trigger email reviewer and author process
+
     }
 }

--- a/app/Console/Commands/ExportEmails.php
+++ b/app/Console/Commands/ExportEmails.php
@@ -13,6 +13,7 @@ use App\Mail\JournalAcceptancePendingMail;
 use App\Mail\ManagementReviewDueMail;
 use App\Mail\ManagementReviewPendingMail;
 use App\Mail\ManuscriptManagementReviewComplete;
+use App\Mail\ManuscriptManagementReviewUnsubmittedMail;
 use App\Mail\ManuscriptRecordSharedMail;
 use App\Mail\ManuscriptRecordSubmittedToDFO;
 use App\Mail\ManuscriptRecordToReviewMail;
@@ -83,6 +84,14 @@ class ExportEmails extends Command
         $manuscriptRecordToReview = new ManuscriptRecordToReviewMail(ManuscriptRecord::factory()->secondary()->in_review(true, true)->create(), User::factory()->create());
         $markdownContent = $manuscriptRecordToReview->render();
         $this->exportFile('manuscript-record-to-review-internal.html', $markdownContent);
+
+        $unsubmittedManuscript = ManuscriptRecord::factory()->in_review()->create();
+        $unsubmittedManuscript->load('user', 'manuscriptAuthors.author');
+        $reviewUser = $unsubmittedManuscript->managementReviewSteps()->with('user')->first()->user;
+        $unsubmittedBy = $unsubmittedManuscript->user;
+        $manuscriptManagementReviewUnsubmitted = new ManuscriptManagementReviewUnsubmittedMail($unsubmittedManuscript, $reviewUser, $unsubmittedBy);
+        $markdownContent = $manuscriptManagementReviewUnsubmitted->render();
+        $this->exportFile('manuscript-management-review-unsubmitted.html', $markdownContent);
 
         // Next reviwer: flagged - return to author
         $mrf = ManagementReviewStep::factory([

--- a/app/Console/Commands/ExportEmails.php
+++ b/app/Console/Commands/ExportEmails.php
@@ -89,7 +89,12 @@ class ExportEmails extends Command
         $unsubmittedManuscript->load('user', 'manuscriptAuthors.author');
         $reviewUser = $unsubmittedManuscript->managementReviewSteps()->with('user')->first()->user;
         $unsubmittedBy = $unsubmittedManuscript->user;
-        $manuscriptManagementReviewUnsubmitted = new ManuscriptManagementReviewUnsubmittedMail($unsubmittedManuscript, $reviewUser, $unsubmittedBy);
+        $manuscriptManagementReviewUnsubmitted = new ManuscriptManagementReviewUnsubmittedMail(
+            $unsubmittedManuscript,
+            $reviewUser,
+            $unsubmittedBy,
+            'Need to update manuscript details before review resumes.',
+        );
         $markdownContent = $manuscriptManagementReviewUnsubmitted->render();
         $this->exportFile('manuscript-management-review-unsubmitted.html', $markdownContent);
 

--- a/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
+++ b/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Events;
 
 use App\Models\ManuscriptRecord;
+use App\Models\User;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
@@ -19,7 +20,7 @@ class ManuscriptManagementReviewUnsubmittedEvent
     /**
      * Create a new event instance.
      */
-    public function __construct(public ManuscriptRecord $manuscriptRecord, public Collection $reviewUsers)
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public Collection $reviewUsers, public User $unsubmittedBy)
     {
         //
     }

--- a/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
+++ b/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
@@ -20,7 +20,7 @@ class ManuscriptManagementReviewUnsubmittedEvent
     /**
      * Create a new event instance.
      */
-    public function __construct(public ManuscriptRecord $manuscriptRecord, public Collection $reviewUsers, public User $unsubmittedBy)
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public Collection $reviewUsers, public User $unsubmittedBy, public string $reason)
     {
         //
     }

--- a/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
+++ b/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Events;
 
 use App\Models\ManuscriptRecord;
-use App\Models\User;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 
 class ManuscriptManagementReviewUnsubmittedEvent
 {
@@ -19,7 +19,7 @@ class ManuscriptManagementReviewUnsubmittedEvent
     /**
      * Create a new event instance.
      */
-    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $reviewUser)
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public Collection $reviewUsers)
     {
         //
     }

--- a/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
+++ b/app/Events/ManuscriptManagementReviewUnsubmittedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\ManuscriptRecord;
+use App\Models\User;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ManuscriptManagementReviewUnsubmittedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $reviewUser)
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Http/Controllers/ManuscriptRecordController.php
+++ b/app/Http/Controllers/ManuscriptRecordController.php
@@ -29,7 +29,6 @@ use App\Traits\PaginationLimitTrait;
 use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\JsonResponse;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Facades\Auth;

--- a/app/Http/Controllers/ManuscriptRecordController.php
+++ b/app/Http/Controllers/ManuscriptRecordController.php
@@ -233,7 +233,14 @@ class ManuscriptRecordController extends Controller
         $manuscriptRecord = $this->loadPolicyRelationships($manuscriptRecord);
         Gate::authorize('unsubmitForReview', $manuscriptRecord);
 
-        UnsubmitManuscriptManagementReview::handle($manuscriptRecord);
+        $validated = $request->validate([
+            'reason' => ['required', 'string', 'min:3', 'max:1000'],
+        ]);
+
+        UnsubmitManuscriptManagementReview::handle(
+            manuscriptRecord: $manuscriptRecord,
+            reason: $validated['reason'],
+        );
 
         return $this->defaultResource($manuscriptRecord);
     }

--- a/app/Http/Controllers/ManuscriptRecordController.php
+++ b/app/Http/Controllers/ManuscriptRecordController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Actions\CloneManuscriptRecord;
 use App\Actions\CreatePublicationFromManuscript;
 use App\Actions\DeleteManuscriptRecord;
+use App\Actions\UnsubmitManuscriptManagementReview;
 use App\Enums\ManuscriptRecordStatus;
 use App\Enums\ManuscriptRecordType;
 use App\Enums\Permissions\UserPermission;
@@ -28,6 +29,7 @@ use App\Traits\PaginationLimitTrait;
 use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResponse;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Facades\Auth;
@@ -223,6 +225,16 @@ class ManuscriptRecordController extends Controller
             // trigger event that the record was submitted
             event(new ManuscriptRecordToReviewEvent($manuscriptRecord, $reviewUser));
         });
+
+        return $this->defaultResource($manuscriptRecord);
+    }
+
+    public function unsubmitForReview(Request $request, ManuscriptRecord $manuscriptRecord): JsonResource
+    {
+        $manuscriptRecord = $this->loadPolicyRelationships($manuscriptRecord);
+        Gate::authorize('unsubmitForReview', $manuscriptRecord);
+
+        UnsubmitManuscriptManagementReview::handle($manuscriptRecord);
 
         return $this->defaultResource($manuscriptRecord);
     }

--- a/app/Http/Resources/ManuscriptRecordResource.php
+++ b/app/Http/Resources/ManuscriptRecordResource.php
@@ -71,6 +71,7 @@ class ManuscriptRecordResource extends JsonResource
                 // special model permissions
                 'can_attach_manuscript' => Auth::user()->can('attachManuscript', $this->resource),
                 'can_resubmit_preprint' => Auth::user()->can('submitToPreprint', $this->resource),
+                'can_unsubmit_for_review' => Auth::user()->can('unsubmitForReview', $this->resource),
             ],
             'can' => [
                 'update' => Auth::user()->can('update', $this->resource),

--- a/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
+++ b/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
@@ -53,6 +53,6 @@ class SendManuscriptManagementReviewUnsubmittedNotification
 
         Mail::to($to->user->email, $to->user->fullName)
             ->cc($ccEmails)
-            ->queue(new ManuscriptManagementReviewUnsubmittedMail($event->manuscriptRecord, $to->user));
+            ->queue(new ManuscriptManagementReviewUnsubmittedMail($event->manuscriptRecord, $to->user, $event->unsubmittedBy));
     }
 }

--- a/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
+++ b/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\ManuscriptManagementReviewUnsubmittedEvent;
+use App\Mail\ManuscriptManagementReviewUnsubmittedMail;
+use Illuminate\Support\Facades\Mail;
+
+class SendManuscriptManagementReviewUnsubmittedNotification
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(ManuscriptManagementReviewUnsubmittedEvent $event): void
+    {
+        Mail::queue(new ManuscriptManagementReviewUnsubmittedMail($event->manuscriptRecord, $event->reviewUser));
+    }
+}

--- a/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
+++ b/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
@@ -23,6 +23,41 @@ class SendManuscriptManagementReviewUnsubmittedNotification
      */
     public function handle(ManuscriptManagementReviewUnsubmittedEvent $event): void
     {
-        Mail::queue(new ManuscriptManagementReviewUnsubmittedMail($event->manuscriptRecord, $event->reviewUser));
+        $event->manuscriptRecord->load('user', 'manuscriptAuthors.author');
+        $event->reviewUsers->each(fn ($reviewUser) => $reviewUser->load('user'));
+
+        // Get latest Manuscript Management Reviewer
+        $to = $event->reviewUsers->last();
+
+        if (! $to) {
+            return; // No reviewer to notify
+        }
+
+        // get reviewer emails
+        $reviewEmails = $event->reviewUsers
+            ->pluck('user.email')
+            ->filter()
+            ->values();
+
+        // get authors emails
+        $authorEmails = $event->manuscriptRecord->manuscriptAuthors
+            ->pluck('author.email')
+            ->filter(fn ($email): bool => $email !== null)
+            ->values();
+
+        // cc all authors and reviewers
+        $ccEmails = $authorEmails
+            ->merge($reviewEmails);
+
+        // deduplicate and remove the TO recipient
+        $ccEmails = $ccEmails
+            ->unique()
+            ->diff([$to->user->email])
+            ->values()
+            ->all();
+
+        Mail::to($to->user->email, $to->user->fullName)
+            ->cc($ccEmails)
+            ->queue(new ManuscriptManagementReviewUnsubmittedMail($event->manuscriptRecord, $to->user));
     }
 }

--- a/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
+++ b/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
@@ -53,6 +53,6 @@ class SendManuscriptManagementReviewUnsubmittedNotification
 
         Mail::to($to->user->email, $to->user->fullName)
             ->cc($ccEmails)
-            ->queue(new ManuscriptManagementReviewUnsubmittedMail($event->manuscriptRecord, $to->user, $event->unsubmittedBy));
+            ->queue(new ManuscriptManagementReviewUnsubmittedMail($event->manuscriptRecord, $to->user, $event->unsubmittedBy, $event->reason));
     }
 }

--- a/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
+++ b/app/Listeners/SendManuscriptManagementReviewUnsubmittedNotification.php
@@ -23,33 +23,28 @@ class SendManuscriptManagementReviewUnsubmittedNotification
      */
     public function handle(ManuscriptManagementReviewUnsubmittedEvent $event): void
     {
-        $event->manuscriptRecord->load('user', 'manuscriptAuthors.author');
-        $event->reviewUsers->each(fn ($reviewUser) => $reviewUser->load('user'));
-
-        // Get latest Manuscript Management Reviewer
         $to = $event->reviewUsers->last();
 
         if (! $to) {
-            return; // No reviewer to notify
+            return;
         }
 
-        // get reviewer emails
+        $event->manuscriptRecord->load('user', 'manuscriptAuthors.author');
+        $event->reviewUsers->each(fn ($reviewUser) => $reviewUser->load('user'));
+
         $reviewEmails = $event->reviewUsers
             ->pluck('user.email')
             ->filter()
             ->values();
 
-        // get authors emails
         $authorEmails = $event->manuscriptRecord->manuscriptAuthors
             ->pluck('author.email')
             ->filter(fn ($email): bool => $email !== null)
             ->values();
 
-        // cc all authors and reviewers
         $ccEmails = $authorEmails
             ->merge($reviewEmails);
 
-        // deduplicate and remove the TO recipient
         $ccEmails = $ccEmails
             ->unique()
             ->diff([$to->user->email])

--- a/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
+++ b/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
@@ -22,7 +22,7 @@ class ManuscriptManagementReviewUnsubmittedMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $reviewUser, public User $unsubmittedBy)
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $reviewUser, public User $unsubmittedBy, public string $reason)
     {
         //
     }
@@ -42,6 +42,7 @@ class ManuscriptManagementReviewUnsubmittedMail extends Mailable
                 'manuscriptRecord' => $this->manuscriptRecord,
                 'user' => $this->reviewUser,
                 'unsubmittedBy' => $this->unsubmittedBy,
+                'reason' => $this->reason,
             ],
         );
     }

--- a/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
+++ b/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
@@ -22,7 +22,7 @@ class ManuscriptManagementReviewUnsubmittedMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $reviewUser)
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $reviewUser, public User $unsubmittedBy)
     {
         //
     }
@@ -41,6 +41,7 @@ class ManuscriptManagementReviewUnsubmittedMail extends Mailable
             with: [
                 'manuscriptRecord' => $this->manuscriptRecord,
                 'user' => $this->reviewUser,
+                'unsubmittedBy' => $this->unsubmittedBy,
             ],
         );
     }

--- a/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
+++ b/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Mail;
 
 use App\Models\ManuscriptRecord;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
 /**
@@ -18,26 +22,26 @@ class ManuscriptManagementReviewUnsubmittedMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $user)
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $reviewUser)
     {
-        $manuscriptRecord->load('user', 'manuscriptAuthors.author.user');
+        //
     }
 
-    public function build()
+    public function envelope(): Envelope
     {
-        $this->subject('Manuscript Unsubmitted from Manuscript Management Review - Manuscrit retiré de l\'examen de gestion du manuscrit : '.$this->manuscriptRecord->title);
-        $this->to($this->user->email, $this->user->fullName);
-        $this->cc($this->manuscriptRecord->user->email, $this->manuscriptRecord->user->fullName);
+        return new Envelope(
+            subject: 'Manuscript Unsubmitted from Manuscript Management Review - Manuscrit retiré de l\'examen de gestion du manuscrit : '.$this->manuscriptRecord->title,
+        );
+    }
 
-        // cc all authors
-        $this->cc(
-            $this->manuscriptRecord->manuscriptAuthors
-                ->pluck('author.user.email')
-                ->filter(fn ($email): bool => $email !== null)
-                ->forget($this->user->email) // don't send to reviewer twice
-                ->toArray());
-
-        return $this->markdown('mail.manuscriptRecord.manuscript-unsubmitted-from-management-review');
-
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.manuscriptRecord.manuscript-unsubmitted-from-management-review',
+            with: [
+                'manuscriptRecord' => $this->manuscriptRecord,
+                'user' => $this->reviewUser,
+            ],
+        );
     }
 }

--- a/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
+++ b/app/Mail/ManuscriptManagementReviewUnsubmittedMail.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\ManuscriptRecord;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Email sent to the Manuscript Management Review contact when the author unsubmits a manuscript for review and returns it to draft.
+ */
+class ManuscriptManagementReviewUnsubmittedMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public ManuscriptRecord $manuscriptRecord, public User $user)
+    {
+        $manuscriptRecord->load('user', 'manuscriptAuthors.author.user');
+    }
+
+    public function build()
+    {
+        $this->subject('Manuscript Unsubmitted from Manuscript Management Review - Manuscrit retiré de l\'examen de gestion du manuscrit : '.$this->manuscriptRecord->title);
+        $this->to($this->user->email, $this->user->fullName);
+        $this->cc($this->manuscriptRecord->user->email, $this->manuscriptRecord->user->fullName);
+
+        // cc all authors
+        $this->cc(
+            $this->manuscriptRecord->manuscriptAuthors
+                ->pluck('author.user.email')
+                ->filter(fn ($email): bool => $email !== null)
+                ->forget($this->user->email) // don't send to reviewer twice
+                ->toArray());
+
+        return $this->markdown('mail.manuscriptRecord.manuscript-unsubmitted-from-management-review');
+
+    }
+}

--- a/app/Models/ManuscriptRecord.php
+++ b/app/Models/ManuscriptRecord.php
@@ -380,6 +380,17 @@ class ManuscriptRecord extends Model implements Fundable, HasMedia, Plannable
     }
 
     /**
+     * Unlock all manuscript files.
+     */
+    public function unlockManuscriptFiles(): void
+    {
+        $this->getManuscriptFiles()->each(function ($media): void {
+            $media->setCustomProperty('locked', false);
+            $media->save();
+        });
+    }
+
+    /**
      * Validate this manuscript record is filled and can be
      * submitted for internal review.
      *

--- a/app/Policies/ManuscriptRecordPolicy.php
+++ b/app/Policies/ManuscriptRecordPolicy.php
@@ -36,7 +36,7 @@ class ManuscriptRecordPolicy
         }
 
         // owners can view their own manuscripts
-        if ($user->id === $manuscriptRecord->user_id) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
 
@@ -45,7 +45,7 @@ class ManuscriptRecordPolicy
             return true;
         }
 
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isAuthor($user, $manuscriptRecord)) {
             return true;
         }
 
@@ -83,12 +83,12 @@ class ManuscriptRecordPolicy
     {
         switch ($manuscriptRecord->status) {
             case ManuscriptRecordStatus::DRAFT:
-                if ($user->id === $manuscriptRecord->user_id) {
+                if ($this->isOwner($user, $manuscriptRecord)) {
                     return true;
                 }
 
                 // Is the the user an author on this manuscript?
-                if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+                if ($this->isAuthor($user, $manuscriptRecord)) {
                     return true;
                 }
 
@@ -112,7 +112,7 @@ class ManuscriptRecordPolicy
                     ->first();
 
                 if ($lastCompletedStep?->decision === ManagementReviewStepDecision::REVISION) {
-                    if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+                    if ($this->isAuthor($user, $manuscriptRecord)) {
                         return true;
                     }
 
@@ -137,7 +137,7 @@ class ManuscriptRecordPolicy
     {
         // can delete if the manuscript is in draft state
         if ($manuscriptRecord->status === ManuscriptRecordStatus::DRAFT) {
-            if ($user->id === $manuscriptRecord->user_id) {
+            if ($this->isOwner($user, $manuscriptRecord)) {
                 return true;
             }
 
@@ -168,11 +168,11 @@ class ManuscriptRecordPolicy
         }
 
         // can attach if the manuscript is the owner of the manuscript
-        if ($user->id === $manuscriptRecord->user_id) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
 
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isAuthor($user, $manuscriptRecord)) {
             return true;
         }
 
@@ -193,12 +193,11 @@ class ManuscriptRecordPolicy
             return false;
         }
 
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
 
-        // can only submit if the user is the owner of the manuscript
-        return $user->id === $manuscriptRecord->user_id;
+        return $this->isAuthor($user, $manuscriptRecord);
     }
 
     /**
@@ -211,12 +210,11 @@ class ManuscriptRecordPolicy
             return false;
         }
 
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
 
-        // can only unsubmit if the user is the owner of the manuscript
-        return $user->id === $manuscriptRecord->user_id;
+        return $this->isAuthor($user, $manuscriptRecord);
     }
 
     /**
@@ -234,7 +232,7 @@ class ManuscriptRecordPolicy
         }
 
         // can only withdraw if the user is the owner of the manuscript
-        return $user->id === $manuscriptRecord->user_id;
+        return $this->isOwner($user, $manuscriptRecord);
     }
 
     /**
@@ -248,11 +246,11 @@ class ManuscriptRecordPolicy
         }
 
         // can only mark as submitted if the user is the owner of the manuscript
-        if ($user->id === $manuscriptRecord->user_id) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
 
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isAuthor($user, $manuscriptRecord)) {
             return true;
         }
         if ($manuscriptRecord->shareables->firstWhere('user_id', $user->id)?->isEditable()) {
@@ -273,10 +271,10 @@ class ManuscriptRecordPolicy
         }
 
         // can only mark as accepted if the user is the owner of the manuscript
-        if ($user->id === $manuscriptRecord->user_id) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isAuthor($user, $manuscriptRecord)) {
             return true;
         }
         if ($manuscriptRecord->shareables->firstWhere('user_id', $user->id)?->isEditable()) {
@@ -300,10 +298,10 @@ class ManuscriptRecordPolicy
         }
 
         // A user can do this multiple times, for example, if they made a mistake in the URL or date.
-        if ($user->id === $manuscriptRecord->user_id) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isAuthor($user, $manuscriptRecord)) {
             return true;
         }
 
@@ -315,11 +313,23 @@ class ManuscriptRecordPolicy
      */
     public function share(User $user, ManuscriptRecord $manuscriptRecord)
     {
-        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+        if ($this->isOwner($user, $manuscriptRecord)) {
             return true;
         }
 
+        return $this->isAuthor($user, $manuscriptRecord);
+    }
+
+    private function isOwner(User $user, ManuscriptRecord $manuscriptRecord): bool
+    {
         return $user->id === $manuscriptRecord->user_id;
+    }
+
+    private function isAuthor(User $user, ManuscriptRecord $manuscriptRecord): bool
+    {
+        return $manuscriptRecord->manuscriptAuthors->contains(
+            fn ($manuscriptAuthor): bool => $manuscriptAuthor->author->user_id === $user->id
+        );
     }
 
     public function updateMedia(User $user, ManuscriptRecord $manuscriptRecord, Media $media): bool

--- a/app/Policies/ManuscriptRecordPolicy.php
+++ b/app/Policies/ManuscriptRecordPolicy.php
@@ -202,6 +202,24 @@ class ManuscriptRecordPolicy
     }
 
     /**
+     * A user can unsubmit a manuscript
+     */
+    public function unsubmitForReview(User $user, ManuscriptRecord $manuscriptRecord): bool
+    {
+        // can only unsubmit if the manuscript is in review
+        if ($manuscriptRecord->status !== ManuscriptRecordStatus::IN_REVIEW) {
+            return false;
+        }
+
+        if ($manuscriptRecord->manuscriptAuthors->contains(fn ($ma): bool => $ma->author->user_id === $user->id)) {
+            return true;
+        }
+
+        // can only unsubmit if the user is the owner of the manuscript
+        return $user->id === $manuscriptRecord->user_id;
+    }
+
+    /**
      * A user can withdraw a manuscript from review
      */
     public function withdraw(User $user, ManuscriptRecord $manuscriptRecord)

--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -590,7 +590,8 @@
     "unsubmit": "Unsubmit",
     "unsubmit-title": "Unsubmit manuscript?",
     "unsubmit-details": "This will return the manuscript to draft so it can be edited again.",
-    "unsubmit-failed": "Unable to unsubmit manuscript."
+    "unsubmit-failed": "Unable to unsubmit manuscript.",
+    "unsubmit-reason-label": "Reason for unsubmission (required)"
   },
   "mrf": {
     "abstract-must-be-at-least-250-characters": "Abstract must be at least 250 characters",

--- a/resources/src/locales/en.json
+++ b/resources/src/locales/en.json
@@ -586,7 +586,11 @@
     "submitted-to-preprint-details": "You've submitted your manuscript to a preprint server. If the server assigns a DOI (Digital Object Identifier), please ensure that it is provided in your submission. If no DOI is available, a stable URL linking directly to the preprint should be included.",
     "go-to-the-preprint": "View preprint (external)",
     "edit-preprint-title": "Edit Preprint Submission",
-    "preprint-url": "Preprint URL"
+    "preprint-url": "Preprint URL",
+    "unsubmit": "Unsubmit",
+    "unsubmit-title": "Unsubmit manuscript?",
+    "unsubmit-details": "This will return the manuscript to draft so it can be edited again.",
+    "unsubmit-failed": "Unable to unsubmit manuscript."
   },
   "mrf": {
     "abstract-must-be-at-least-250-characters": "Abstract must be at least 250 characters",

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -590,7 +590,8 @@
     "unsubmit": "Annuler la soumission",
     "unsubmit-title": "Annuler l'envoi du manuscrit ?",
     "unsubmit-details": "Cela ramènera le manuscrit à l'état de brouillon afin qu'il puisse être modifié à nouveau.",
-    "unsubmit-failed": "Impossible de retirer le manuscrit"
+    "unsubmit-failed": "Impossible de retirer le manuscrit",
+    "unsubmit-reason-label": "Raison du retrait de la soumission (obligatoire)"
 
   },
   "mrf": {

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -592,7 +592,6 @@
     "unsubmit-details": "Cela ramènera le manuscrit à l'état de brouillon afin qu'il puisse être modifié à nouveau.",
     "unsubmit-failed": "Impossible de retirer le manuscrit"
 
-
   },
   "mrf": {
     "abstract-must-be-at-least-250-characters": "Le résumé doit comporter au moins 250 caractères",

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -587,8 +587,8 @@
     "edit-preprint-title": "Modifier la soumission de préparation",
     "go-to-the-preprint": "Afficher la prépublication (externe)",
     "preprint-url": "URL de prépublication",
-    "unsubmit": "Annuler la soumission",
-    "unsubmit-title": "Annuler l'envoi du manuscrit ?",
+    "unsubmit": "Retirer la soumission",
+    "unsubmit-title": "Retirer la soumission du manuscrit ?",
     "unsubmit-details": "Cela ramènera le manuscrit à l'état de brouillon afin qu'il puisse être modifié à nouveau.",
     "unsubmit-failed": "Impossible de retirer le manuscrit",
     "unsubmit-reason-label": "Raison du retrait de la soumission (obligatoire)"

--- a/resources/src/locales/fr.json
+++ b/resources/src/locales/fr.json
@@ -586,7 +586,13 @@
     "submit-preprint-title": "Marquez comme publié",
     "edit-preprint-title": "Modifier la soumission de préparation",
     "go-to-the-preprint": "Afficher la prépublication (externe)",
-    "preprint-url": "URL de prépublication"
+    "preprint-url": "URL de prépublication",
+    "unsubmit": "Annuler la soumission",
+    "unsubmit-title": "Annuler l'envoi du manuscrit ?",
+    "unsubmit-details": "Cela ramènera le manuscrit à l'état de brouillon afin qu'il puisse être modifié à nouveau.",
+    "unsubmit-failed": "Impossible de retirer le manuscrit"
+
+
   },
   "mrf": {
     "abstract-must-be-at-least-250-characters": "Le résumé doit comporter au moins 250 caractères",

--- a/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
+++ b/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
@@ -212,12 +212,12 @@ export class ManuscriptRecordService {
     return response.data
   }
 
-/** Unsubmit this manuscript record */
-public static async unsubmitForReview(id: number) {
-  const response = await http.put(`${this.baseURL}/${id}/unsubmit-for-review`)
+  /** Unsubmit this manuscript record */
+  public static async unsubmitForReview(id: number) {
+    const response = await http.put(`${this.baseURL}/${id}/unsubmit-for-review`)
 
-  return response.data
-}
+    return response.data
+  }
 
   /** Mark this manuscript as being submitted to a journal */
   public static async submitted(id: number, date: string) {

--- a/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
+++ b/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
@@ -213,8 +213,11 @@ export class ManuscriptRecordService {
   }
 
   /** Unsubmit this manuscript record */
-  public static async unsubmitForReview(id: number) {
-    const response = await http.put(`${this.baseURL}/${id}/unsubmit-for-review`)
+  public static async unsubmitForReview(
+    id: number,
+    reason: string,
+  ): Promise<ManuscriptRecordResource> {
+    const response = await http.put<UnsubmitReviewReason, ManuscriptRecordResource>(`${this.baseURL}/${id}/unsubmit-for-review`, { reason })
 
     return response.data
   }
@@ -426,6 +429,10 @@ export class ManuscriptRecordListQuery extends SpatieQuery {
     super.sort(name, direction)
     return this
   }
+}
+
+interface UnsubmitReviewReason {
+  reason: string
 }
 
 type ManuscriptQuerySort

--- a/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
+++ b/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
@@ -212,6 +212,13 @@ export class ManuscriptRecordService {
     return response.data
   }
 
+/** Unsubmit this manuscript record */
+public static async unsubmitForReview(id: number) {
+  const response = await http.put(`${this.baseURL}/${id}/unsubmit-for-review`)
+
+  return response.data
+}
+
   /** Mark this manuscript as being submitted to a journal */
   public static async submitted(id: number, date: string) {
     const data = {

--- a/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
+++ b/resources/src/models/ManuscriptRecord/ManuscriptRecord.ts
@@ -68,6 +68,7 @@ export interface ManuscriptRecord extends BaseManuscriptRecord {
   // special model permissions
   can_attach_manuscript: boolean
   can_resubmit_preprint: boolean
+  can_unsubmit_for_review: boolean
 }
 
 export type ManuscriptRecordSummary = Omit<

--- a/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
+++ b/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
@@ -6,8 +6,8 @@ import { useQuasar } from 'quasar'
 import AcceptedByJournalDialog from '../components/AcceptedByJournalDialog.vue'
 import ManuscriptStatusSpan from '../components/ManuscriptStatusSpan.vue'
 import SubmittedToJournalDialog from '../components/SubmittedToJournalDialog.vue'
-import UnsubmitManuscriptButton from './UnsubmitManuscriptButton.vue'
 import WithdrawManuscriptDialog from '../components/WithdrawManuscriptDialog.vue'
+import UnsubmitManuscriptButton from './UnsubmitManuscriptButton.vue'
 
 const manuscriptRecord = defineModel<ManuscriptRecordResource>({ required: true })
 
@@ -144,7 +144,6 @@ const withdrawnSubtitle = computed(() => {
   )
 })
 
-
 function unsubmitForReview(record: ManuscriptRecordResource) {
   manuscriptRecord.value = record
 }
@@ -171,8 +170,6 @@ function withdrawManuscript(record: ManuscriptRecordResource) {
   showWithdrawManuscriptDialog.value = false
   updateManuscriptandNotify(record)
 }
-
-
 
 function updateManuscriptandNotify(record: ManuscriptRecordResource) {
   manuscriptRecord.value = record
@@ -229,10 +226,10 @@ function updateManuscriptandNotify(record: ManuscriptRecordResource) {
         {{ $t('manuscript-progress-view.completed-details') }}
       </p>
       <UnsubmitManuscriptButton
-  v-if="canUnsubmitForReview"
-  :manuscript-record-id="manuscriptRecord.data.id"
-  @unsubmitted="unsubmitForReview"
-/>
+        v-if="canUnsubmitForReview"
+        :manuscript-record-id="manuscriptRecord.data.id"
+        @unsubmitted="unsubmitForReview"
+      />
     </q-timeline-entry>
     <q-timeline-entry
       v-if="manuscriptRecord.data.status !== 'withdrawn'"

--- a/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
+++ b/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
@@ -87,7 +87,7 @@ const canUnsubmitForReview = computed(() => {
     return false
   }
 
-  return Boolean(manuscriptRecord.value.can?.update && manuscriptRecord.value.data.can_unsubmit_for_review)
+  return Boolean(manuscriptRecord.value.data.can_unsubmit_for_review)
 })
 
 const submittedToJournalSubtitle = computed(() => {

--- a/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
+++ b/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
@@ -83,7 +83,11 @@ const managementReviewIcon = computed(() => {
 })
 
 const canUnsubmitForReview = computed(() => {
-  return manuscriptRecord.value?.data.status === 'in_review'
+  if (manuscriptRecord.value?.data.status !== 'in_review') {
+    return false
+  }
+
+  return Boolean(manuscriptRecord.value.can?.update && manuscriptRecord.value.data.can_unsubmit_for_review)
 })
 
 const submittedToJournalSubtitle = computed(() => {

--- a/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
+++ b/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
@@ -2,6 +2,7 @@
 import type {
   ManuscriptRecordResource,
 } from '../ManuscriptRecord'
+import { ManuscriptRecordService } from '../ManuscriptRecord'
 import { useQuasar } from 'quasar'
 import AcceptedByJournalDialog from '../components/AcceptedByJournalDialog.vue'
 import ManuscriptStatusSpan from '../components/ManuscriptStatusSpan.vue'
@@ -81,6 +82,10 @@ const managementReviewIcon = computed(() => {
   return 'mdi-thumb-up-outline'
 })
 
+const canUnsubmitForReview = computed(() => {
+  return manuscriptRecord.value?.data.status === 'in_review'
+})
+
 const submittedToJournalSubtitle = computed(() => {
   if (manuscriptRecord.value === null) {
     return ''
@@ -139,6 +144,47 @@ const withdrawnSubtitle = computed(() => {
   )
 })
 
+const unsubmitLoading = ref(false)
+
+function confirmUnsubmitManuscript() {
+  $q.dialog({
+    title: t('manuscript-progress-view.unsubmit-title'),
+    message: t('manuscript-progress-view.unsubmit-details'),
+    cancel: true,
+    persistent: true,
+    ok: {
+      label: t('common.confirm'),
+      color: 'negative',
+    },
+  }).onOk(() => {
+    unsubmitManuscript()
+  })
+}
+
+async function unsubmitManuscript() {
+  if (!manuscriptRecord.value) {
+    return
+  }
+ unsubmitLoading.value = true
+
+  try {
+    const record = await ManuscriptRecordService.unsubmitForReview(
+      manuscriptRecord.value.data.id,
+    )
+
+    updateManuscriptandNotify(record)
+  }
+  catch {
+    $q.notify({
+      message: t('manuscript-progress-view.unsubmit-failed'),
+      color: 'negative',
+      icon: 'mdi-alert-circle-outline',
+    })
+  }
+  finally {
+    unsubmitLoading.value = false
+  }
+}
 // submitted to journal dialog
 const showSubmittedToJournalDialog = ref(false)
 
@@ -216,6 +262,14 @@ function updateManuscriptandNotify(record: ManuscriptRecordResource) {
       <p>
         {{ $t('manuscript-progress-view.completed-details') }}
       </p>
+      <q-btn
+  v-if="canUnsubmitForReview"
+  color="negative"
+  outline
+  icon="mdi-undo"
+  :label="$t('manuscript-progress-view.unsubmit')"
+  @click="confirmUnsubmitManuscript()"
+/>
     </q-timeline-entry>
     <q-timeline-entry
       v-if="manuscriptRecord.data.status !== 'withdrawn'"

--- a/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
+++ b/resources/src/models/ManuscriptRecord/components/ManuscriptRecordProgressPrimary.vue
@@ -2,11 +2,11 @@
 import type {
   ManuscriptRecordResource,
 } from '../ManuscriptRecord'
-import { ManuscriptRecordService } from '../ManuscriptRecord'
 import { useQuasar } from 'quasar'
 import AcceptedByJournalDialog from '../components/AcceptedByJournalDialog.vue'
 import ManuscriptStatusSpan from '../components/ManuscriptStatusSpan.vue'
 import SubmittedToJournalDialog from '../components/SubmittedToJournalDialog.vue'
+import UnsubmitManuscriptButton from './UnsubmitManuscriptButton.vue'
 import WithdrawManuscriptDialog from '../components/WithdrawManuscriptDialog.vue'
 
 const manuscriptRecord = defineModel<ManuscriptRecordResource>({ required: true })
@@ -144,47 +144,11 @@ const withdrawnSubtitle = computed(() => {
   )
 })
 
-const unsubmitLoading = ref(false)
 
-function confirmUnsubmitManuscript() {
-  $q.dialog({
-    title: t('manuscript-progress-view.unsubmit-title'),
-    message: t('manuscript-progress-view.unsubmit-details'),
-    cancel: true,
-    persistent: true,
-    ok: {
-      label: t('common.confirm'),
-      color: 'negative',
-    },
-  }).onOk(() => {
-    unsubmitManuscript()
-  })
+function unsubmitForReview(record: ManuscriptRecordResource) {
+  manuscriptRecord.value = record
 }
 
-async function unsubmitManuscript() {
-  if (!manuscriptRecord.value) {
-    return
-  }
- unsubmitLoading.value = true
-
-  try {
-    const record = await ManuscriptRecordService.unsubmitForReview(
-      manuscriptRecord.value.data.id,
-    )
-
-    updateManuscriptandNotify(record)
-  }
-  catch {
-    $q.notify({
-      message: t('manuscript-progress-view.unsubmit-failed'),
-      color: 'negative',
-      icon: 'mdi-alert-circle-outline',
-    })
-  }
-  finally {
-    unsubmitLoading.value = false
-  }
-}
 // submitted to journal dialog
 const showSubmittedToJournalDialog = ref(false)
 
@@ -207,6 +171,8 @@ function withdrawManuscript(record: ManuscriptRecordResource) {
   showWithdrawManuscriptDialog.value = false
   updateManuscriptandNotify(record)
 }
+
+
 
 function updateManuscriptandNotify(record: ManuscriptRecordResource) {
   manuscriptRecord.value = record
@@ -262,13 +228,10 @@ function updateManuscriptandNotify(record: ManuscriptRecordResource) {
       <p>
         {{ $t('manuscript-progress-view.completed-details') }}
       </p>
-      <q-btn
+      <UnsubmitManuscriptButton
   v-if="canUnsubmitForReview"
-  color="negative"
-  outline
-  icon="mdi-undo"
-  :label="$t('manuscript-progress-view.unsubmit')"
-  @click="confirmUnsubmitManuscript()"
+  :manuscript-record-id="manuscriptRecord.data.id"
+  @unsubmitted="unsubmitForReview"
 />
     </q-timeline-entry>
     <q-timeline-entry

--- a/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
+++ b/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
@@ -3,10 +3,8 @@
   lang="ts"
 >
 import type { ManuscriptRecordResource } from '../ManuscriptRecord'
-import { useQuasar } from 'quasar'
 import { ref } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { ManuscriptRecordService } from '../ManuscriptRecord'
+import UnsubmitManuscriptDialog from './UnsubmitManuscriptDialog.vue'
 
 const props = defineProps<{
   manuscriptRecordId: number
@@ -16,62 +14,30 @@ const emit = defineEmits<{
   unsubmitted: [manuscriptRecord: ManuscriptRecordResource]
 }>()
 
-const { t } = useI18n()
-const $q = useQuasar()
+const showDialog = ref(false)
 
-const loading = ref(false)
-
-function confirmUnsubmitManuscript() {
-  $q.dialog({
-    title: t('manuscript-progress-view.unsubmit-title'),
-    message: t('manuscript-progress-view.unsubmit-details'),
-    prompt: {
-      model: '',
-      type: 'textarea',
-      label: t('manuscript-progress-view.unsubmit-reason-label'),
-      isValid: val => val.trim().length > 2,
-    },
-    cancel: true,
-    persistent: false,
-    ok: {
-      label: t('common.confirm'),
-      color: 'negative',
-    },
-  }).onOk((value: string) => {
-    unsubmitManuscript(value)
-  })
-}
-
-async function unsubmitManuscript(reason: string) {
-  loading.value = true
-
-  try {
-    const manuscriptRecord = await ManuscriptRecordService.unsubmitForReview(
-      props.manuscriptRecordId,
-      reason,
-    )
-    emit('unsubmitted', manuscriptRecord)
-  }
-  catch {
-    $q.notify({
-      message: t('manuscript-progress-view.unsubmit-failed'),
-      color: 'negative',
-      icon: 'mdi-alert-circle-outline',
-    })
-  }
-  finally {
-    loading.value = false
-  }
+function unsubmitted(manuscriptRecord: ManuscriptRecordResource) {
+  showDialog.value = false
+  emit('unsubmitted', manuscriptRecord)
 }
 </script>
 
 <template>
-  <q-btn
-    color="negative"
-    outline
-    icon="mdi-undo"
-    :label="$t('manuscript-progress-view.unsubmit')"
-    :loading="loading"
-    @click="confirmUnsubmitManuscript"
-  />
+  <div>
+    <q-btn
+      color="negative"
+      outline
+      icon="mdi-undo"
+      v-bind="$attrs"
+      :label="$t('manuscript-progress-view.unsubmit')"
+      @click="showDialog = true"
+    />
+
+    <UnsubmitManuscriptDialog
+      v-if="showDialog"
+      v-model="showDialog"
+      :manuscript-record-id="props.manuscriptRecordId"
+      @updated="unsubmitted"
+    />
+  </div>
 </template>

--- a/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
+++ b/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
@@ -3,8 +3,8 @@
   lang="ts"
 >
 import type { ManuscriptRecordResource } from '../ManuscriptRecord'
-import { ref } from 'vue'
 import { useQuasar } from 'quasar'
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ManuscriptRecordService } from '../ManuscriptRecord'
 
@@ -37,24 +37,24 @@ function confirmUnsubmitManuscript() {
 }
 
 async function unsubmitManuscript() {
-    loading.value = true
+  loading.value = true
 
-    try {
-        const manuscriptRecord = await ManuscriptRecordService.unsubmitForReview(
-  props.manuscriptRecordId,
-)
-        emit('unsubmitted', manuscriptRecord)
-    }
-    catch {
-        $q.notify({
-        message: t('manuscript-progress-view.unsubmit-failed'),
-        color: 'negative',
-        icon: 'mdi-alert-circle-outline',
-        })
-    }
-    finally {
-        loading.value = false
-    }
+  try {
+    const manuscriptRecord = await ManuscriptRecordService.unsubmitForReview(
+      props.manuscriptRecordId,
+    )
+    emit('unsubmitted', manuscriptRecord)
+  }
+  catch {
+    $q.notify({
+      message: t('manuscript-progress-view.unsubmit-failed'),
+      color: 'negative',
+      icon: 'mdi-alert-circle-outline',
+    })
+  }
+  finally {
+    loading.value = false
+  }
 }
 </script>
 

--- a/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
+++ b/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
@@ -1,0 +1,70 @@
+<script
+  setup
+  lang="ts"
+>
+import type { ManuscriptRecordResource } from '../ManuscriptRecord'
+import { ref } from 'vue'
+import { useQuasar } from 'quasar'
+import { useI18n } from 'vue-i18n'
+import { ManuscriptRecordService } from '../ManuscriptRecord'
+
+const props = defineProps<{
+  manuscriptRecordId: number
+}>()
+
+const emit = defineEmits<{
+  unsubmitted: [manuscriptRecord: ManuscriptRecordResource]
+}>()
+
+const { t } = useI18n()
+const $q = useQuasar()
+
+const loading = ref(false)
+
+function confirmUnsubmitManuscript() {
+  $q.dialog({
+    title: t('manuscript-progress-view.unsubmit-title'),
+    message: t('manuscript-progress-view.unsubmit-details'),
+    cancel: true,
+    persistent: false,
+    ok: {
+      label: t('common.confirm'),
+      color: 'negative',
+    },
+  }).onOk(() => {
+    unsubmitManuscript()
+  })
+}
+
+async function unsubmitManuscript() {
+    loading.value = true
+
+    try {
+        const manuscriptRecord = await ManuscriptRecordService.unsubmitForReview(
+  props.manuscriptRecordId,
+)
+        emit('unsubmitted', manuscriptRecord)
+    }
+    catch {
+        $q.notify({
+        message: t('manuscript-progress-view.unsubmit-failed'),
+        color: 'negative',
+        icon: 'mdi-alert-circle-outline',
+        })
+    }
+    finally {
+        loading.value = false
+    }
+}
+</script>
+
+<template>
+  <q-btn
+    color="negative"
+    outline
+    icon="mdi-undo"
+    :label="$t('manuscript-progress-view.unsubmit')"
+    :loading="loading"
+    @click="confirmUnsubmitManuscript"
+  />
+</template>

--- a/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
+++ b/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptButton.vue
@@ -25,23 +25,30 @@ function confirmUnsubmitManuscript() {
   $q.dialog({
     title: t('manuscript-progress-view.unsubmit-title'),
     message: t('manuscript-progress-view.unsubmit-details'),
+    prompt: {
+      model: '',
+      type: 'textarea',
+      label: t('manuscript-progress-view.unsubmit-reason-label'),
+      isValid: val => val.trim().length > 2,
+    },
     cancel: true,
     persistent: false,
     ok: {
       label: t('common.confirm'),
       color: 'negative',
     },
-  }).onOk(() => {
-    unsubmitManuscript()
+  }).onOk((value: string) => {
+    unsubmitManuscript(value)
   })
 }
 
-async function unsubmitManuscript() {
+async function unsubmitManuscript(reason: string) {
   loading.value = true
 
   try {
     const manuscriptRecord = await ManuscriptRecordService.unsubmitForReview(
       props.manuscriptRecordId,
+      reason,
     )
     emit('unsubmitted', manuscriptRecord)
   }

--- a/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptDialog.vue
+++ b/resources/src/models/ManuscriptRecord/components/UnsubmitManuscriptDialog.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { ManuscriptRecordResource } from '../ManuscriptRecord'
+import { QBtn, QCardActions, QForm, QInput, useQuasar } from 'quasar'
+import BaseDialog from '@/components/BaseDialog.vue'
+import { ManuscriptRecordService } from '../ManuscriptRecord'
+
+const props = defineProps<{
+  manuscriptRecordId: number
+}>()
+
+const emit = defineEmits<{
+  (event: 'updated', arg: ManuscriptRecordResource): void
+}>()
+
+const showDialog = defineModel<boolean>({ required: true })
+
+const { t } = useI18n()
+const $q = useQuasar()
+
+const loading = ref(false)
+const reason = ref('')
+
+const isReasonValid = computed(() => {
+  return reason.value.trim().length > 2
+})
+
+async function submit() {
+  if (!isReasonValid.value) {
+    return
+  }
+
+  loading.value = true
+
+  try {
+    const manuscriptRecord = await ManuscriptRecordService.unsubmitForReview(
+      props.manuscriptRecordId,
+      reason.value,
+    )
+    emit('updated', manuscriptRecord)
+  }
+  catch {
+    $q.notify({
+      message: t('manuscript-progress-view.unsubmit-failed'),
+      color: 'negative',
+      icon: 'mdi-alert-circle-outline',
+    })
+  }
+  finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <BaseDialog v-model="showDialog" persistent :title="$t('manuscript-progress-view.unsubmit-title')">
+    <div class="q-pa-md text-body1">
+      <p>
+        {{ $t('manuscript-progress-view.unsubmit-details') }}
+      </p>
+      <QForm @submit="submit">
+        <QInput
+          v-model="reason"
+          :label="$t('manuscript-progress-view.unsubmit-reason-label')"
+          outlined
+          type="textarea"
+          autogrow
+          :rules="[(val: string) => val.trim().length > 2 || $t('common.required')]"
+        />
+        <QCardActions align="right">
+          <QBtn
+            v-close-popup
+            :label="$t('common.cancel')"
+            color="secondary"
+            outline
+          />
+          <QBtn
+            color="negative"
+            :label="$t('common.confirm')"
+            type="submit"
+            :disable="!isReasonValid"
+            :loading="loading"
+          />
+        </QCardActions>
+      </QForm>
+    </div>
+  </BaseDialog>
+</template>
+
+<style scoped></style>

--- a/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
+++ b/resources/src/models/ManuscriptRecord/views/ManuscriptRecordFormView.vue
@@ -22,6 +22,7 @@ import ManuscriptStatusBadge from '../components/ManuscriptStatusBadge.vue'
 import ManuscriptTypeBadge from '../components/ManuscriptTypeBadge.vue'
 import PlainLanguageSummarySection from '../components/PlainLanguageSummarySection.vue'
 import SubmitManuscriptDialog from '../components/SubmitManuscriptDialog.vue'
+import UnsubmitManuscriptButton from '../components/UnsubmitManuscriptButton.vue'
 import YesNoBooleanOptionGroup from '../components/YesNoBooleanOptionGroup.vue'
 import {
   ManuscriptRecordService,
@@ -289,6 +290,16 @@ function onSubmitted(manuscript: ManuscriptRecordResource) {
                 icon="mdi-delete-outline"
                 :label="$t('common.delete')"
                 @deleted="$router.push({ name: 'dashboard' })"
+              />
+              <UnsubmitManuscriptButton
+                v-if="manuscriptResource.data.can_unsubmit_for_review"
+                :manuscript-record-id="manuscriptResource.data.id"
+                flat
+                size="sm"
+                color="red"
+                icon="mdi-undo"
+                :label="$t('manuscript-progress-view.unsubmit')"
+                @unsubmitted="onSubmitted"
               />
             </div>
           </div>

--- a/resources/views/mail/manuscriptRecord/manuscript-unsubmitted-from-management-review.blade.php
+++ b/resources/views/mail/manuscriptRecord/manuscript-unsubmitted-from-management-review.blade.php
@@ -1,0 +1,42 @@
+<x-mail::message>
+# Hello {{ $user->first_name }},
+
+*(le français suit)*
+
+A manuscript record submission from {{ $manuscriptRecord->user->fullname }} has been unsubmitted from the Manuscript Management Review queue and returned to draft.
+
+A Manuscript Management Review is no longer expected for this manuscript record. If you have any questions, please contact the author.
+
+<x-mail::panel>
+# Manuscript Summary
+**Working Title:**<br /> {{ $manuscriptRecord->title }}
+
+**Author(s):**<br /> {{ $manuscriptRecord->manuscriptAuthors->implode('author.apaName', '; ') }}
+
+**Abstract:** <br />{!! $manuscriptRecord->abstract !!}
+</x-mail::panel>
+
+<x-email.regards locale="en" />
+
+---
+<br />
+
+# Bonjour {{ $user->first_name }},
+
+Une soumission de dossier de manuscrit de {{ $manuscriptRecord->user->fullname }} a été retirée de la file d'attente de l'examen de gestion du manuscrit et remise à l'état de brouillon.
+
+Un examen de gestion du manuscrit n'est plus requis pour ce dossier de manuscrit. Si vous avez des questions, veuillez communiquer avec l'auteur.
+
+<x-mail::panel>
+# Résumé du manuscrit
+
+**Titre de travail :**<br /> {{ $manuscriptRecord->title }}
+
+**Auteur(s) :**<br /> {{ $manuscriptRecord->manuscriptAuthors->implode('author.apaName', '; ') }}
+
+**Résumé :**<br />{!! $manuscriptRecord->abstract !!}
+</x-mail::panel>
+
+<x-email.regards locale="fr" />
+
+</x-mail::message>

--- a/resources/views/mail/manuscriptRecord/manuscript-unsubmitted-from-management-review.blade.php
+++ b/resources/views/mail/manuscriptRecord/manuscript-unsubmitted-from-management-review.blade.php
@@ -5,6 +5,8 @@
 
 A manuscript record submission has been unsubmitted from the Manuscript Management Review queue by {{ $unsubmittedBy->fullName }} and returned to draft.
 
+**Reason for unsubmission:**<br /> {{ $reason }}
+
 A Manuscript Management Review is no longer expected for this manuscript record. If you have any questions, please contact the author.
 
 <x-mail::panel>
@@ -24,6 +26,8 @@ A Manuscript Management Review is no longer expected for this manuscript record.
 # Bonjour {{ $user->first_name }},
 
 Une soumission au registre du manuscrit a été retirée de la révision par la gestion par {{ $unsubmittedBy->fullName }} et remise à l'état de brouillon.
+
+**Raison du retrait de la soumission :**<br /> {{ $reason }}
 
 Une révision par la gestion du manuscrit n'est plus requise pour ce dossier de manuscrit. Si vous avez des questions, veuillez communiquer avec l'auteur.
 

--- a/resources/views/mail/manuscriptRecord/manuscript-unsubmitted-from-management-review.blade.php
+++ b/resources/views/mail/manuscriptRecord/manuscript-unsubmitted-from-management-review.blade.php
@@ -3,7 +3,7 @@
 
 *(le français suit)*
 
-A manuscript record submission from {{ $manuscriptRecord->user->fullname }} has been unsubmitted from the Manuscript Management Review queue and returned to draft.
+A manuscript record submission has been unsubmitted from the Manuscript Management Review queue by {{ $unsubmittedBy->fullName }} and returned to draft.
 
 A Manuscript Management Review is no longer expected for this manuscript record. If you have any questions, please contact the author.
 
@@ -23,9 +23,9 @@ A Manuscript Management Review is no longer expected for this manuscript record.
 
 # Bonjour {{ $user->first_name }},
 
-Une soumission de dossier de manuscrit de {{ $manuscriptRecord->user->fullname }} a été retirée de la file d'attente de l'examen de gestion du manuscrit et remise à l'état de brouillon.
+Une soumission au registre du manuscrit a été retirée de la révision par la gestion par {{ $unsubmittedBy->fullName }} et remise à l'état de brouillon.
 
-Un examen de gestion du manuscrit n'est plus requis pour ce dossier de manuscrit. Si vous avez des questions, veuillez communiquer avec l'auteur.
+Une révision par la gestion du manuscrit n'est plus requise pour ce dossier de manuscrit. Si vous avez des questions, veuillez communiquer avec l'auteur.
 
 <x-mail::panel>
 # Résumé du manuscrit

--- a/routes/api.php
+++ b/routes/api.php
@@ -134,6 +134,7 @@ Route::middleware(['auth:sanctum'])->group(function () {
         Route::post('/manuscript-records', 'store');
         // actions
         Route::put('manuscript-records/{manuscriptRecord}/submit-for-review', 'submitForReview');
+        Route::put('manuscript-records/{manuscriptRecord}/unsubmit-for-review', 'unsubmitForReview');
         Route::put('manuscript-records/{manuscriptRecord}/withdraw', 'withdraw');
         Route::put('manuscript-records/{manuscriptRecord}/submitted', 'submitted');
         Route::put('manuscript-records/{manuscriptRecord}/submitted-to-preprint', 'submittedToPreprint');

--- a/tests/Feature/Models/ManuscriptRecordTest.php
+++ b/tests/Feature/Models/ManuscriptRecordTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\ManagementReviewStepDecision;
 use App\Enums\ManagementReviewStepStatus;
 use App\Enums\ManuscriptRecordStatus;
 use App\Enums\ManuscriptRecordType;
@@ -13,6 +14,7 @@ use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
+use Spatie\Activitylog\Models\Activity;
 
 test('an authenticated user can create a new manuscript', function (): void {
     $user = User::factory()->create();
@@ -291,6 +293,61 @@ test('a MRF author can edit and submit a filled manuscript record', function ():
     expect($manuscript->managementReviewSteps()->count())->toBe(1);
     expect($manuscript->managementReviewSteps()->first()->user_id)->toBe($reviewerUser->id);
     expect($manuscript->managementReviewSteps()->first()->status)->toBe(ManagementReviewStepStatus::PENDING);
+});
+
+test('an owner can unsubmit an in review manuscript and unlock manuscript files', function (): void {
+    Event::fake();
+
+    $manuscript = ManuscriptRecord::factory()->in_review()->create();
+    $reviewer = $manuscript->managementReviewSteps()->first()?->user;
+
+    $manuscript->managementReviewSteps()->first()?->update([
+        'status' => ManagementReviewStepStatus::COMPLETED,
+        'decision' => ManagementReviewStepDecision::REVISION,
+        'comments' => 'Please revise methods section',
+        'completed_at' => now(),
+    ]);
+
+    $this->actingAs($manuscript->user)
+        ->putJson("/api/manuscript-records/{$manuscript->id}/unsubmit-for-review", [
+            'reason' => 'Need to update manuscript after co-author feedback.',
+        ])
+        ->assertOk()
+        ->assertJsonPath('data.status', ManuscriptRecordStatus::DRAFT->value)
+        ->assertJsonPath('data.sent_for_review_at', null)
+        ->assertJsonPath('data.can_unsubmit_for_review', false);
+
+    $manuscript->refresh();
+
+    expect($manuscript->status)->toBe(ManuscriptRecordStatus::DRAFT);
+    expect($manuscript->managementReviewSteps()->count())->toBe(0);
+    expect($manuscript->getLastManuscriptFile()?->getCustomProperty('locked'))->toBeFalse();
+
+    $activity = Activity::query()
+        ->where('subject_type', ManuscriptRecord::class)
+        ->where('subject_id', $manuscript->id)
+        ->where('event', 'unsubmitted')
+        ->latest('id')
+        ->first();
+
+    expect($activity)->not->toBeNull();
+
+    $oldProperties = data_get($activity?->properties?->toArray(), 'old');
+    expect($oldProperties)->toHaveKeys(['status', 'sent_for_review_at', 'management_review_steps']);
+    expect(data_get($oldProperties, 'management_review_steps.0.user_id'))->toBe($reviewer?->id);
+    expect(data_get($oldProperties, 'management_review_steps.0.decision'))->toBe(ManagementReviewStepDecision::REVISION->value);
+    expect(data_get($oldProperties, 'management_review_steps.0.comments'))->toBe('Please revise methods section');
+});
+
+test('an unsubmit reason with fewer than three non whitespace characters is rejected', function (): void {
+    $manuscript = ManuscriptRecord::factory()->in_review()->create();
+
+    $this->actingAs($manuscript->user)
+        ->putJson("/api/manuscript-records/{$manuscript->id}/unsubmit-for-review", [
+            'reason' => '  a',
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['reason']);
 });
 
 test('a user can withdraw a manuscript record', function (): void {


### PR DESCRIPTION
# i1471: allow manuscript management review unsubmission

## Summary

Adds the ability for eligible users to unsubmit a manuscript record from Manuscript Management Review and return it to draft.

## Changes

* adds an unsubmit action for manuscript records in review
* adds authorization and validation for the unsubmit workflow
* requires users to provide a reason before unsubmitting
* records the unsubmit reason and status changes in the activity log
* removes associated management review steps when the record is returned to draft
* adds an API endpoint and frontend service method for unsubmit-for-review
* adds a reusable unsubmit button to the manuscript progress timeline
* sends a bilingual notification email to the latest management reviewer and CCs relevant authors/reviewers
* adds English and French translation strings for the unsubmit dialog and email

closes #1471
